### PR TITLE
Added command to check bot permissions

### DIFF
--- a/src/main/java/de/fbrettnich/easypoll/commands/SetupPermissionsCommand.java
+++ b/src/main/java/de/fbrettnich/easypoll/commands/SetupPermissionsCommand.java
@@ -1,0 +1,69 @@
+/*
+ * EasyPoll Discord Bot (https://github.com/fbrettnich/easypoll-bot)
+ * Copyright (C) 2021  Felix Brettnich
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.fbrettnich.easypoll.commands;
+
+import io.sentry.Sentry;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+
+import javax.annotation.Nonnull;
+import java.awt.*;
+
+public class SetupPermissionsCommand {
+
+    public SetupPermissionsCommand(@Nonnull SlashCommandEvent event) {
+
+        if(event.getGuild() == null) return;
+
+        Member member = event.getGuild().getSelfMember();
+        GuildChannel guildChannel = event.getGuildChannel();
+
+        EmbedBuilder eb = new EmbedBuilder();
+
+        eb.setTitle("Required Bot Permission Check", "https://github.com/fbrettnich/easypoll-bot/wiki/Required-Bot-Permissions");
+        eb.setColor(Color.decode("#FDA50F"));
+        eb.setDescription(
+                "**Server Permissions**\n" +
+                        (member.hasPermission(Permission.MESSAGE_READ) ? ":white_check_mark:" : ":no_entry_sign:") + " Read Messages\n" +
+                        (member.hasPermission(Permission.MESSAGE_WRITE) ? ":white_check_mark:" : ":no_entry_sign:") + " Send Messages\n" +
+                        (member.hasPermission(Permission.MESSAGE_MANAGE) ? ":white_check_mark:" : ":no_entry_sign:") + " Manage Messages\n" +
+                        (member.hasPermission(Permission.MESSAGE_EMBED_LINKS) ? ":white_check_mark:" : ":no_entry_sign:") + " Embed Links\n" +
+                        (member.hasPermission(Permission.MESSAGE_HISTORY) ? ":white_check_mark:" : ":no_entry_sign:") + " Read message History\n" +
+                        (member.hasPermission(Permission.MESSAGE_ADD_REACTION) ? ":white_check_mark:" : ":no_entry_sign:") + " Add Reactions\n" +
+                        (member.hasPermission(Permission.MESSAGE_EXT_EMOJI) ? ":white_check_mark:" : ":no_entry_sign:") + " Use External Emojis\n" +
+                        "\n" +
+                "**Channel Permissions** (#" + event.getChannel().getName() + ")\n" +
+                        (member.hasPermission(guildChannel, Permission.MESSAGE_READ) ? ":white_check_mark:" : ":no_entry_sign:") + " Read Messages\n" +
+                        (member.hasPermission(guildChannel, Permission.MESSAGE_WRITE) ? ":white_check_mark:" : ":no_entry_sign:") + " Send Messages\n" +
+                        (member.hasPermission(guildChannel, Permission.MESSAGE_MANAGE) ? ":white_check_mark:" : ":no_entry_sign:") + " Manage Messages\n" +
+                        (member.hasPermission(guildChannel, Permission.MESSAGE_EMBED_LINKS) ? ":white_check_mark:" : ":no_entry_sign:") + " Embed Links\n" +
+                        (member.hasPermission(guildChannel, Permission.MESSAGE_HISTORY) ? ":white_check_mark:" : ":no_entry_sign:") + " Read message History\n" +
+                        (member.hasPermission(guildChannel, Permission.MESSAGE_ADD_REACTION) ? ":white_check_mark:" : ":no_entry_sign:") + " Add Reactions\n" +
+                        (member.hasPermission(guildChannel, Permission.MESSAGE_EXT_EMOJI) ? ":white_check_mark:" : ":no_entry_sign:") + " Use External Emojis"
+        );
+
+        event.replyEmbeds(
+                eb.build()
+        ).queue(null, Sentry::captureException);
+
+    }
+}

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -31,6 +31,7 @@ import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.sharding.DefaultShardManagerBuilder;
 import net.dv8tion.jda.api.sharding.ShardManager;
@@ -287,6 +288,12 @@ public class Main {
                                 .addOption(OptionType.STRING, "answer18", "Answer 18")
                                 .addOption(OptionType.STRING, "answer19", "Answer 19")
                                 .addOption(OptionType.STRING, "answer20", "Answer 20")
+                )
+                .addCommands(
+                        new CommandData("setup", "Bot setup and settings")
+                                .addSubcommands(
+                                        new SubcommandData("permissions", "Check required bot permissions")
+                                )
                 )
                 .queue(null, Sentry::captureException);
     }

--- a/src/main/java/de/fbrettnich/easypoll/listener/SlashCommandListener.java
+++ b/src/main/java/de/fbrettnich/easypoll/listener/SlashCommandListener.java
@@ -34,6 +34,7 @@ public class SlashCommandListener  extends ListenerAdapter {
         if(event.getGuild() == null) return;
 
         String commandName = event.getName();
+        String subCommandName = event.getSubcommandName();
 
         switch (commandName) {
             case "closepoll":
@@ -70,6 +71,15 @@ public class SlashCommandListener  extends ListenerAdapter {
             case "timepoll":
                 new PollCommand(event, true);
                 Statistics.insertCommandUsage(StatisticsCommands.SLASH_TIMEPOLL);
+                break;
+
+            case "setup":
+                if(subCommandName == null) break;
+                switch (subCommandName) {
+                    case "permissions":
+                        new SetupPermissionsCommand(event);
+                        break;
+                }
                 break;
 
             case "vote":


### PR DESCRIPTION
<!--
Please read the contributing guidelines to contribute properly!
Contributing Guidelines: https://github.com/fbrettnich/easypoll-bot/blob/main/.github/CONTRIBUTING.md
-->

### Changes

- [x] New feature
- [ ] Bug fixes
- [ ] Documentation
- [ ] Other: \___ <!-- Insert another type -->

Closes #2 <!-- Replace 'NaN' with a issue number that belongs to this pull request. -->

### Description
With this PR the new command to check the required bot permissions is added.
When executing the command (`/setup permissions`) the required permissions on server and channel level are checked. The user receives a response with a list and the status of the permissions.

![image](https://user-images.githubusercontent.com/42101045/129415302-b4e1b98f-5997-4c58-8e3e-b6b9bbb750d9.png)