### PR TITLE
Introduce the guild-specific language selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,17 @@ You can also find help on how to invite the bot in our Wiki: [Invite Bot to Serv
 
 ## Usage & Commands
 
-| Command     | Description                                                                                                             |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------- |
-| /poll       | Create a normal poll without time limit and with up to 20 own answers                                                   |
-| /timepoll   | Create a timed poll, set an end date until when the poll will run. Use time specifications for this like 10m / 3h / 1d  |
-| /closepoll  | Close a poll so that no more votes are counted and display the final result                                             |
-| /easypoll   | Get a list and help with all commands                                                                                   |
-| /vote       | Vote for the EasyPoll Bot                                                                                               |
-| /invite     | Invite EasyPoll to your own Discord Serve                                                                               |
-| /info       | Show some information about EasyPoll                                                                                    |
-| /ping       | See the Ping of the Bot to the Discord Gateway                                                                          |
+| Command         | Description                                                                                                             |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| /poll           | Create a normal poll without time limit and with up to 20 own answers                                                   |
+| /timepoll       | Create a timed poll, set an end date until when the poll will run. Use time specifications for this like 10m / 3h / 1d  |
+| /closepoll      | Close a poll so that no more votes are counted and display the final result                                             |
+| /easypoll       | Get a list and help with all commands                                                                                   |
+| /vote           | Vote for the EasyPoll Bot                                                                                               |
+| /invite         | Invite EasyPoll to your own Discord Serve                                                                               |
+| /info           | Show some information about EasyPoll                                                                                    |
+| /ping           | See the Ping of the Bot to the Discord Gateway                                                                          |
+| /setup language | Change the Bot language of the current Guild                                                                            |
 
 ## Getting Help
 If you have any questions about using the EasyPoll Bot, feel free to visit the official [EasyPoll Support Discord][discord-invite]  

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ We are happy about any contribution &#9786;
 - [emoji-java](https://github.com/vdurmont/emoji-java)
 - [sentry-java](https://github.com/getsentry/sentry-java)
 - [unirest-java](https://github.com/Kong/unirest-java)
+- [json-simple](https://github.com/fangyidong/json-simple)
 
 ## Self-Hosting
 Running your own version of EasyPoll Bot is not supported.  

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
             <artifactId>unirest-java</artifactId>
             <version>3.11.09</version>
         </dependency>
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/de/fbrettnich/easypoll/commands/ClosePollCommand.java
+++ b/src/main/java/de/fbrettnich/easypoll/commands/ClosePollCommand.java
@@ -19,6 +19,7 @@
 package de.fbrettnich.easypoll.commands;
 
 import de.fbrettnich.easypoll.core.Constants;
+import de.fbrettnich.easypoll.language.GuildLanguage;
 import de.fbrettnich.easypoll.utils.Permissions;
 import de.fbrettnich.easypoll.utils.PollManager;
 import io.sentry.Sentry;
@@ -38,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 public class ClosePollCommand {
 
-    public ClosePollCommand(@Nonnull SlashCommandEvent event) {
+    public ClosePollCommand(@Nonnull SlashCommandEvent event, GuildLanguage gl) {
 
         event.deferReply().queue(null, Sentry::captureException);
 
@@ -62,9 +63,9 @@ public class ClosePollCommand {
             EmbedBuilder eb = new EmbedBuilder();
 
             eb.setColor(Color.RED);
-            eb.setTitle("You do not have premissions to use this command!", Constants.WEBSITE_URL);
+            eb.setTitle(gl.getTl("errors.no_permissions.member.title"), Constants.WEBSITE_URL);
             eb.addField(
-                    "To use this command you need at least one of them:",
+                    gl.getTl("errors.no_permissions.member.field.title"),
                     "\u2022 ADMINISTRATOR *(Permission)*\n" +
                             "\u2022 MANAGE_PERMISSIONS *(Permission)*\n" +
                             "\u2022 PollCreator *(Role)*\n" +
@@ -89,16 +90,13 @@ public class ClosePollCommand {
         if(pm.canClosePollByPollId(pollId, event.getGuild().getId())) {
             pm.closePollByPollId(pollId);
 
-            eb.setTitle("Poll closed", Constants.WEBSITE_URL);
+            eb.setTitle(gl.getTl("commands.closepoll.success.title"), Constants.WEBSITE_URL);
             eb.setColor(Color.decode("#01FF70"));
-            eb.setDescription(
-                    "The poll with ID **" + pollId + "** was closed!\n" +
-                    "No more votes are allowed and the result is now displayed in the poll."
-            );
+            eb.setDescription(gl.getTl("commands.closepoll.success.description", pollId));
         }else{
-            eb.setTitle("Poll can not be closed", Constants.WEBSITE_URL);
+            eb.setTitle(gl.getTl("commands.closepoll.failed.title"), Constants.WEBSITE_URL);
             eb.setColor(Color.RED);
-            eb.setDescription("The poll with ID **" + pollId + "** does not exist or is already closed!\n");
+            eb.setDescription(gl.getTl("commands.closepoll.failed.description", pollId));
         }
 
         hook.sendMessageEmbeds(

--- a/src/main/java/de/fbrettnich/easypoll/commands/HelpCommand.java
+++ b/src/main/java/de/fbrettnich/easypoll/commands/HelpCommand.java
@@ -19,6 +19,7 @@
 package de.fbrettnich.easypoll.commands;
 
 import de.fbrettnich.easypoll.core.Constants;
+import de.fbrettnich.easypoll.language.GuildLanguage;
 import io.sentry.Sentry;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
@@ -28,28 +29,28 @@ import java.awt.*;
 
 public class HelpCommand {
 
-    public HelpCommand(@Nonnull SlashCommandEvent event) {
+    public HelpCommand(@Nonnull SlashCommandEvent event, GuildLanguage gl) {
 
         EmbedBuilder eb = new EmbedBuilder();
 
-        eb.setTitle("EasyPoll Help", Constants.WEBSITE_URL);
+        eb.setTitle(gl.getTl("commands.help.title"), Constants.WEBSITE_URL);
         eb.setColor(Color.decode("#FDA50F"));
 
         eb.addField(
-                ":bar_chart: Poll Commands",
-                "**/poll** \u2022 Create a normal poll without time limit\n" +
-                        "**/timepoll** \u2022 Create a timed poll, set an end date until when the poll will run\n" +
-                        "**/closepoll** \u2022 Close a poll so that no more votes are counted",
+                gl.getTl("commands.help.fields.poll_commands.title"),
+                "**/poll** \u2022 " + gl.getTl("commands.help.fields.poll_commands.commands.poll") + "\n" +
+                        "**/timepoll** \u2022 " + gl.getTl("commands.help.fields.poll_commands.commands.timepoll") + "\n" +
+                        "**/closepoll** \u2022 " + gl.getTl("commands.help.fields.poll_commands.commands.closepoll"),
                 false
         );
 
         eb.addField(
-                ":mag_right: Public Commands",
-                "**/help** \u2022 Show this Bot Help\n" +
-                        "**/vote** \u2022 Vote for the EasyPoll Bot\n" +
-                        "**/invite** \u2022 Invite EasyPoll to your own Discord Server\n" +
-                        "**/info** \u2022 Show some information about EasyPoll\n" +
-                        "**/ping** \u2022 See the Ping of the Bot to the Discord Gateway",
+                gl.getTl("commands.help.fields.public_commands.title"),
+                "**/help** \u2022 " + gl.getTl("commands.help.fields.public_commands.commands.help") + "\n" +
+                        "**/vote** \u2022 " + gl.getTl("commands.help.fields.public_commands.commands.vote") + "\n" +
+                        "**/invite** \u2022 " + gl.getTl("commands.help.fields.public_commands.commands.invite") + "\n" +
+                        "**/info** \u2022 " + gl.getTl("commands.help.fields.public_commands.commands.info") + "\n" +
+                        "**/ping** \u2022 " + gl.getTl("commands.help.fields.public_commands.commands.ping"),
                 false
         );
 

--- a/src/main/java/de/fbrettnich/easypoll/commands/InfoCommand.java
+++ b/src/main/java/de/fbrettnich/easypoll/commands/InfoCommand.java
@@ -20,6 +20,7 @@ package de.fbrettnich.easypoll.commands;
 
 import de.fbrettnich.easypoll.core.Constants;
 import de.fbrettnich.easypoll.core.Main;
+import de.fbrettnich.easypoll.language.GuildLanguage;
 import de.fbrettnich.easypoll.utils.FormatUtil;
 import io.sentry.Sentry;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -31,25 +32,25 @@ import java.awt.*;
 
 public class InfoCommand {
 
-    public InfoCommand(@Nonnull SlashCommandEvent event) {
+    public InfoCommand(@Nonnull SlashCommandEvent event, GuildLanguage gl) {
 
         EmbedBuilder eb = new EmbedBuilder();
 
-        eb.setTitle("EasyPoll Information", Constants.WEBSITE_URL);
+        eb.setTitle(gl.getTl("commands.info.title"), Constants.WEBSITE_URL);
         eb.setColor(Color.decode("#01FF70"));
         eb.setThumbnail(event.getJDA().getSelfUser().getEffectiveAvatarUrl());
 
-        eb.addField("Creator", Constants.BOT_OWNER_MENTION, false);
-        eb.addField("Repository", "[github.com/fbrettnich/easypoll-bot](https://github.com/fbrettnich/easypoll-bot)", false);
-        eb.addField("Version", Constants.VERSION, false);
+        eb.addField(gl.getTl("commands.info.fields.creator"), Constants.BOT_OWNER_MENTION, false);
+        eb.addField(gl.getTl("commands.info.fields.repository"), "[github.com/fbrettnich/easypoll-bot](https://github.com/fbrettnich/easypoll-bot)", false);
+        eb.addField(gl.getTl("commands.info.fields.version"), Constants.VERSION, false);
 
-        eb.addField("Library", "[JDA (Java Discord API)](https://github.com/DV8FromTheWorld/JDA)", false);
+        eb.addField(gl.getTl("commands.info.fields.library"), "[JDA (Java Discord API)](https://github.com/DV8FromTheWorld/JDA)", false);
 
-        eb.addField("Servers", FormatUtil.decimalFormat(Main.getShardManager().getGuilds().size()), false);
-        eb.addField("Users", FormatUtil.decimalFormat(Main.getShardManager().getGuilds().stream().mapToInt(Guild::getMemberCount).sum()), false);
+        eb.addField(gl.getTl("commands.info.fields.servers"), FormatUtil.decimalFormat(Main.getShardManager().getGuilds().size()), false);
+        eb.addField(gl.getTl("commands.info.fields.users"), FormatUtil.decimalFormat(Main.getShardManager().getGuilds().stream().mapToInt(Guild::getMemberCount).sum()), false);
 
-        eb.addField("Shard", (event.getGuild().getJDA().getShardInfo().getShardId() + 1) + "/" + Main.getShardManager().getShardsTotal(), false);
-        eb.addField("Uptime", getUptime(), false);
+        eb.addField(gl.getTl("commands.info.fields.shard"), (event.getGuild().getJDA().getShardInfo().getShardId() + 1) + "/" + Main.getShardManager().getShardsTotal(), false);
+        eb.addField(gl.getTl("commands.info.fields.uptime"), getUptime(), false);
 
         event.replyEmbeds(
                 eb.build()

--- a/src/main/java/de/fbrettnich/easypoll/commands/InviteCommand.java
+++ b/src/main/java/de/fbrettnich/easypoll/commands/InviteCommand.java
@@ -19,6 +19,7 @@
 package de.fbrettnich.easypoll.commands;
 
 import de.fbrettnich.easypoll.core.Constants;
+import de.fbrettnich.easypoll.language.GuildLanguage;
 import io.sentry.Sentry;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
@@ -28,15 +29,13 @@ import java.awt.*;
 
 public class InviteCommand {
 
-    public InviteCommand(@Nonnull SlashCommandEvent event) {
+    public InviteCommand(@Nonnull SlashCommandEvent event, GuildLanguage gl) {
 
         EmbedBuilder eb = new EmbedBuilder();
 
-        eb.setTitle("Invite EasyPoll", Constants.INVITE_URL);
+        eb.setTitle(gl.getTl("commands.invite.title"), Constants.INVITE_URL);
         eb.setColor(Color.decode("#5865F2"));
-        eb.setDescription(
-                "You can invite " + event.getJDA().getSelfUser().getAsMention() + " here: [www.easypoll.me/invite](" + Constants.INVITE_URL + ")"
-        );
+        eb.setDescription(gl.getTl("commands.invite.description", event.getJDA().getSelfUser().getAsMention(), Constants.INVITE_URL));
 
         event.replyEmbeds(
                 eb.build()

--- a/src/main/java/de/fbrettnich/easypoll/commands/PingCommand.java
+++ b/src/main/java/de/fbrettnich/easypoll/commands/PingCommand.java
@@ -18,6 +18,7 @@
 
 package de.fbrettnich.easypoll.commands;
 
+import de.fbrettnich.easypoll.language.GuildLanguage;
 import io.sentry.Sentry;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
@@ -27,15 +28,13 @@ import java.awt.*;
 
 public class PingCommand {
 
-    public PingCommand(@Nonnull SlashCommandEvent event) {
+    public PingCommand(@Nonnull SlashCommandEvent event, GuildLanguage gl) {
 
         EmbedBuilder eb = new EmbedBuilder();
 
-        eb.setTitle("Pong! :ping_pong:");
+        eb.setTitle(gl.getTl("commands.ping.title"));
         eb.setColor(Color.decode("#4CBB17"));
-        eb.setDescription(
-                "`Ping to Gateway " + ((int) event.getJDA().getGatewayPing()) + " ms`"
-        );
+        eb.setDescription(gl.getTl("commands.ping.description", String.valueOf(((int) event.getJDA().getGatewayPing()))));
 
         event.replyEmbeds(
                 eb.build()

--- a/src/main/java/de/fbrettnich/easypoll/commands/PollCommand.java
+++ b/src/main/java/de/fbrettnich/easypoll/commands/PollCommand.java
@@ -20,6 +20,7 @@ package de.fbrettnich.easypoll.commands;
 
 import com.vdurmont.emoji.EmojiManager;
 import de.fbrettnich.easypoll.core.Constants;
+import de.fbrettnich.easypoll.language.GuildLanguage;
 import de.fbrettnich.easypoll.utils.Permissions;
 import de.fbrettnich.easypoll.utils.PollManager;
 import de.fbrettnich.easypoll.utils.enums.PollType;
@@ -45,7 +46,7 @@ import java.util.regex.Pattern;
 
 public class PollCommand {
 
-    public PollCommand(@Nonnull SlashCommandEvent event, boolean isTimePoll) {
+    public PollCommand(@Nonnull SlashCommandEvent event, GuildLanguage gl, boolean isTimePoll) {
 
         event.deferReply().queue(null, Sentry::captureException);
 
@@ -69,9 +70,9 @@ public class PollCommand {
             EmbedBuilder eb = new EmbedBuilder();
 
             eb.setColor(Color.RED);
-            eb.setTitle("You do not have premissions to use this command!", Constants.WEBSITE_URL);
+            eb.setTitle(gl.getTl("errors.no_permissions.member.title"), Constants.WEBSITE_URL);
             eb.addField(
-                    "To use this command you need at least one of them:",
+                    gl.getTl("errors.no_permissions.member.field.title"),
                     "\u2022 ADMINISTRATOR *(Permission)*\n" +
                             "\u2022 MANAGE_PERMISSIONS *(Permission)*\n" +
                             "\u2022 PollCreator *(Role)*\n" +
@@ -134,13 +135,10 @@ public class PollCommand {
                 EmbedBuilder eb = new EmbedBuilder();
 
                 eb.setColor(Color.ORANGE);
-                eb.setTitle("Invalid time specification!", Constants.WEBSITE_URL);
+                eb.setTitle(gl.getTl("commands.poll.invalid_time.title"), Constants.WEBSITE_URL);
                 eb.addField(
-                        "You have entered an invalid time!",
-                        "Used at the end of a number s (second), m (minute), h (hour), d (day) or w (week) for time specifications.\n" +
-                                "Examples: 15m for 15 minutes, 1h for 1 hour, 3d for 3 days\n" +
-                                "\n" +
-                                "*PS: You will find your sent command of this poll to copy as a message to which I replied (click on the blue `/timepoll` command above this message)*",
+                        gl.getTl("commands.poll.invalid_time.field.title"),
+                        gl.getTl("commands.poll.invalid_time.field.description"),
                         true);
 
                 hook.sendMessageEmbeds(
@@ -171,7 +169,8 @@ public class PollCommand {
                                 null,
                                 question,
                                 null,
-                                null
+                                null,
+                                gl
                         )
                 ).complete();
             }catch (Exception e) {
@@ -202,8 +201,8 @@ public class PollCommand {
                 EmbedBuilder eb = new EmbedBuilder();
 
                 eb.setColor(Color.RED);
-                eb.setTitle("I do not have permissions to add reactions to the messages in the specified channel.");
-                eb.addField("Please make sure that I have the following permissions",
+                eb.setTitle(gl.getTl("errors.no_permissions.bot.title"));
+                eb.addField(gl.getTl("errors.no_permissions.bot.field.title"),
                         "MESSAGE_WRITE, MESSAGE_MANAGE, MESSAGE_EMBED_LINKS, MESSAGE_HISTORY, MESSAGE_ADD_REACTION, MESSAGE_EXT_EMOJI",
                         true);
 
@@ -264,7 +263,8 @@ public class PollCommand {
                                 allowmultiplechoices,
                                 question,
                                 reactionsList,
-                                choiceList
+                                choiceList,
+                                gl
                         )
                 ).complete();
             }catch (Exception e) {
@@ -297,12 +297,10 @@ public class PollCommand {
 
                         EmbedBuilder eb = new EmbedBuilder();
                         eb.setColor(Color.ORANGE);
-                        eb.setTitle("Unknown Emoji", Constants.WEBSITE_URL);
+                        eb.setTitle(gl.getTl("commands.poll.unknown_emoji.title"), Constants.WEBSITE_URL);
                         eb.addField(
-                                "You have specified an unknown emoji!",
-                                "Please make sure it is an **official Discord** emoji or an emoji **from this server**. EasyPoll can only use emojis from servers where EasyPoll is too.\n" +
-                                        "\n" +
-                                        "*PS: You will find your sent command of this poll to copy as a message to which I replied (click on the blue `" + (isTimePoll ? "/timepoll" : "/poll") +  "` command above this message)*",
+                                gl.getTl("commands.poll.unknown_emoji.field.title"),
+                                gl.getTl("commands.poll.unknown_emoji.field.description", (isTimePoll ? "/timepoll" : "/poll")),
                                 true);
 
                         message.clearReactions().queue(null, Sentry::captureException);
@@ -315,8 +313,8 @@ public class PollCommand {
                         EmbedBuilder eb = new EmbedBuilder();
 
                         eb.setColor(Color.RED);
-                        eb.setTitle("I do not have permissions to add reactions to the messages in the specified channel.");
-                        eb.addField("Please make sure that I have the following permissions",
+                        eb.setTitle(gl.getTl("errors.no_permissions.bot.title"));
+                        eb.addField(gl.getTl("errors.no_permissions.bot.field.title"),
                                 "MESSAGE_WRITE, MESSAGE_MANAGE, MESSAGE_EMBED_LINKS, MESSAGE_HISTORY, MESSAGE_ADD_REACTION, MESSAGE_EXT_EMOJI",
                                 true);
 
@@ -332,8 +330,8 @@ public class PollCommand {
                     EmbedBuilder eb = new EmbedBuilder();
 
                     eb.setColor(Color.RED);
-                    eb.setTitle("I do not have permissions to add reactions to the messages in the specified channel.");
-                    eb.addField("Please make sure that I have the following permissions",
+                    eb.setTitle(gl.getTl("errors.no_permissions.bot.title"));
+                    eb.addField(gl.getTl("errors.no_permissions.bot.field.title"),
                             "MESSAGE_WRITE, MESSAGE_MANAGE, MESSAGE_EMBED_LINKS, MESSAGE_HISTORY, MESSAGE_ADD_REACTION, MESSAGE_EXT_EMOJI",
                             true);
 

--- a/src/main/java/de/fbrettnich/easypoll/commands/SetupLanguageCommand.java
+++ b/src/main/java/de/fbrettnich/easypoll/commands/SetupLanguageCommand.java
@@ -1,0 +1,115 @@
+/*
+ * EasyPoll Discord Bot (https://github.com/fbrettnich/easypoll-bot)
+ * Copyright (C) 2021  Felix Brettnich
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.fbrettnich.easypoll.commands;
+
+import de.fbrettnich.easypoll.core.Constants;
+import de.fbrettnich.easypoll.core.Main;
+import de.fbrettnich.easypoll.language.GuildLanguage;
+import de.fbrettnich.easypoll.language.TranslationManager;
+import io.sentry.Sentry;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Emoji;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.exceptions.ErrorHandler;
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.interactions.components.selections.SelectionMenu;
+import net.dv8tion.jda.api.requests.ErrorResponse;
+
+import javax.annotation.Nonnull;
+import java.awt.*;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+public class SetupLanguageCommand {
+
+    public SetupLanguageCommand(@Nonnull SlashCommandEvent event, GuildLanguage gl) {
+
+        event.deferReply().queue(null, Sentry::captureException);
+
+        TranslationManager tm = Main.getTranslationManager();
+        InteractionHook hook = event.getHook();
+        Member member = event.getMember();
+
+        if(member == null) return;
+
+        if(
+                !member.isOwner() &&
+                !member.hasPermission(Permission.ADMINISTRATOR) &&
+                !member.hasPermission(Permission.MANAGE_PERMISSIONS)
+        )
+        {
+
+            EmbedBuilder eb = new EmbedBuilder();
+
+            eb.setColor(Color.RED);
+            eb.setTitle(gl.getTl("errors.no_permissions.member.title"), Constants.WEBSITE_URL);
+            eb.addField(
+                    gl.getTl("errors.no_permissions.member.field.title"),
+                    "\u2022 ADMINISTRATOR *(Permission)*\n" +
+                            "\u2022 MANAGE_PERMISSIONS *(Permission)*",
+                    true);
+
+            hook.sendMessageEmbeds(
+                            eb.build()
+                    )
+                    .delay(30, TimeUnit.SECONDS)
+                    .flatMap(Message::delete)
+                    .queue(null, new ErrorHandler()
+                            .ignore(ErrorResponse.UNKNOWN_MESSAGE)
+                            .handle(Objects::nonNull, Sentry::captureException)
+                    );
+
+            return;
+        }
+
+
+        EmbedBuilder eb = new EmbedBuilder();
+
+        eb.setTitle(gl.getTl("commands.setup.language.change.title"), Constants.WEBSITE_URL);
+        eb.setColor(Color.decode("#01FF70"));
+        eb.setDescription(gl.getTl("commands.setup.language.change.description"));
+
+
+        SelectionMenu.Builder selectionMenuBuilder = SelectionMenu
+                .create("ChangeLanguageMenu")
+                .setPlaceholder(gl.getTl("commands.setup.language.change.selectionmenu.placeholder"))
+                .setMinValues(1)
+                .setMaxValues(1);
+
+        tm.getLanguages().forEach(lang -> selectionMenuBuilder.addOption(
+                        tm.getTranslation(lang, "translation.name_local"),
+                        lang,
+                        tm.getTranslation(lang, "translation.name"),
+                        Emoji.fromUnicode(tm.getTranslation(lang, "translation.flag_unicode"))
+                )
+        );
+
+        hook.sendMessageEmbeds(
+                        eb.build()
+                )
+                .addActionRow(
+                        selectionMenuBuilder.build()
+                )
+                .queue(null, Sentry::captureException);
+
+    }
+}

--- a/src/main/java/de/fbrettnich/easypoll/commands/SetupPermissionsCommand.java
+++ b/src/main/java/de/fbrettnich/easypoll/commands/SetupPermissionsCommand.java
@@ -19,7 +19,7 @@
 package de.fbrettnich.easypoll.commands;
 
 import de.fbrettnich.easypoll.core.Constants;
-import de.fbrettnich.easypoll.utils.Permissions;
+import de.fbrettnich.easypoll.language.GuildLanguage;
 import io.sentry.Sentry;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 public class SetupPermissionsCommand {
 
-    public SetupPermissionsCommand(@Nonnull SlashCommandEvent event) {
+    public SetupPermissionsCommand(@Nonnull SlashCommandEvent event, GuildLanguage gl) {
 
         event.deferReply().queue(null, Sentry::captureException);
 
@@ -59,9 +59,9 @@ public class SetupPermissionsCommand {
             EmbedBuilder eb = new EmbedBuilder();
 
             eb.setColor(Color.RED);
-            eb.setTitle("You do not have premissions to use this command!", Constants.WEBSITE_URL);
+            eb.setTitle(gl.getTl("errors.no_permissions.member.title"), Constants.WEBSITE_URL);
             eb.addField(
-                    "To use this command you need at least one of them:",
+                    gl.getTl("errors.no_permissions.member.field.title"),
                     "\u2022 ADMINISTRATOR *(Permission)*\n" +
                             "\u2022 MANAGE_PERMISSIONS *(Permission)*",
                     true);
@@ -81,26 +81,26 @@ public class SetupPermissionsCommand {
 
         EmbedBuilder eb = new EmbedBuilder();
 
-        eb.setTitle("Required Bot Permission Check", "https://github.com/fbrettnich/easypoll-bot/wiki/Required-Bot-Permissions");
+        eb.setTitle(gl.getTl("commands.setup.permissions.title"), "https://github.com/fbrettnich/easypoll-bot/wiki/Required-Bot-Permissions");
         eb.setColor(Color.decode("#FDA50F"));
         eb.setDescription(
-                "**Server Permissions**\n" +
-                        (selfMember.hasPermission(Permission.MESSAGE_READ) ? ":white_check_mark:" : ":no_entry_sign:") + " Read Messages\n" +
-                        (selfMember.hasPermission(Permission.MESSAGE_WRITE) ? ":white_check_mark:" : ":no_entry_sign:") + " Send Messages\n" +
-                        (selfMember.hasPermission(Permission.MESSAGE_MANAGE) ? ":white_check_mark:" : ":no_entry_sign:") + " Manage Messages\n" +
-                        (selfMember.hasPermission(Permission.MESSAGE_EMBED_LINKS) ? ":white_check_mark:" : ":no_entry_sign:") + " Embed Links\n" +
-                        (selfMember.hasPermission(Permission.MESSAGE_HISTORY) ? ":white_check_mark:" : ":no_entry_sign:") + " Read message History\n" +
-                        (selfMember.hasPermission(Permission.MESSAGE_ADD_REACTION) ? ":white_check_mark:" : ":no_entry_sign:") + " Add Reactions\n" +
-                        (selfMember.hasPermission(Permission.MESSAGE_EXT_EMOJI) ? ":white_check_mark:" : ":no_entry_sign:") + " Use External Emojis\n" +
+                "**" + gl.getTl("commands.setup.permissions.server_permissions") + "**\n" +
+                        (selfMember.hasPermission(Permission.MESSAGE_READ) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_read") + "\n" +
+                        (selfMember.hasPermission(Permission.MESSAGE_WRITE) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_write") + "\n" +
+                        (selfMember.hasPermission(Permission.MESSAGE_MANAGE) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_manage") + "\n" +
+                        (selfMember.hasPermission(Permission.MESSAGE_EMBED_LINKS) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_embed_links") + "\n" +
+                        (selfMember.hasPermission(Permission.MESSAGE_HISTORY) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_history") + "\n" +
+                        (selfMember.hasPermission(Permission.MESSAGE_ADD_REACTION) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_add_reaction") + "\n" +
+                        (selfMember.hasPermission(Permission.MESSAGE_EXT_EMOJI) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_ext_emoji") + "\n" +
                         "\n" +
-                "**Channel Permissions** (#" + event.getChannel().getName() + ")\n" +
-                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_READ) ? ":white_check_mark:" : ":no_entry_sign:") + " Read Messages\n" +
-                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_WRITE) ? ":white_check_mark:" : ":no_entry_sign:") + " Send Messages\n" +
-                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_MANAGE) ? ":white_check_mark:" : ":no_entry_sign:") + " Manage Messages\n" +
-                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_EMBED_LINKS) ? ":white_check_mark:" : ":no_entry_sign:") + " Embed Links\n" +
-                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_HISTORY) ? ":white_check_mark:" : ":no_entry_sign:") + " Read message History\n" +
-                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_ADD_REACTION) ? ":white_check_mark:" : ":no_entry_sign:") + " Add Reactions\n" +
-                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_EXT_EMOJI) ? ":white_check_mark:" : ":no_entry_sign:") + " Use External Emojis"
+                "**" + gl.getTl("commands.setup.permissions.channel_permissions") + "** (#" + event.getChannel().getName() + ")\n" +
+                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_READ) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_read") + "\n" +
+                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_WRITE) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_write") + "\n" +
+                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_MANAGE) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_manage") + "\n" +
+                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_EMBED_LINKS) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_embed_links") + "\n" +
+                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_HISTORY) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_history") + "\n" +
+                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_ADD_REACTION) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_add_reaction") + "\n" +
+                        (selfMember.hasPermission(guildChannel, Permission.MESSAGE_EXT_EMOJI) ? ":white_check_mark:" : ":no_entry_sign:") + " " + gl.getTl("commands.setup.permissions.permissions.message_ext_emoji") + ""
         );
 
         hook.sendMessageEmbeds(

--- a/src/main/java/de/fbrettnich/easypoll/commands/VoteCommand.java
+++ b/src/main/java/de/fbrettnich/easypoll/commands/VoteCommand.java
@@ -19,6 +19,7 @@
 package de.fbrettnich.easypoll.commands;
 
 import de.fbrettnich.easypoll.core.Constants;
+import de.fbrettnich.easypoll.language.GuildLanguage;
 import io.sentry.Sentry;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
@@ -28,16 +29,15 @@ import java.awt.*;
 
 public class VoteCommand {
 
-    public VoteCommand(@Nonnull SlashCommandEvent event) {
+    public VoteCommand(@Nonnull SlashCommandEvent event, GuildLanguage gl) {
 
         EmbedBuilder eb = new EmbedBuilder();
 
-        eb.setTitle("Vote for EasyPoll", Constants.VOTE_URL);
+        eb.setTitle(gl.getTl("commands.vote.title"), Constants.VOTE_URL);
         eb.setColor(Color.decode("#01FF70"));
-        eb.setDescription("" +
-                "We are happy that you want to vote for our bot. You show us that you like the bot and help us to grow further.\n" +
+        eb.setDescription(
+                gl.getTl("commands.vote.description") +
                 "\n" +
-                "You can vote for us on the following pages:\n" +
                 "\u2022 [top.gg/bot/437618149505105920](https://top.gg/bot/437618149505105920/vote)\n" +
                 "\u2022 [discordbotlist.com/bots/easypoll](https://discordbotlist.com/bots/easypoll/upvote)\n"
         );

--- a/src/main/java/de/fbrettnich/easypoll/core/Constants.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Constants.java
@@ -25,6 +25,7 @@ public class Constants {
     public static boolean DEVMODE = true;
 
     public static final String VERSION = "3.0.0";
+    public static final String DEFAULT_LANGUAGE = "en-us";
 
     public static String BOT_ID = "";
     public static final String BOT_OWNER_MENTION = "<@231091710195662848>";

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -77,7 +77,7 @@ public class Main {
         });
 
         translationManager = new TranslationManager();
-        translationManager.loadTranslations("de-at", "de-de", "en-us", "nl-nl", "pt-br");
+        translationManager.loadTranslations("de-at", "de-de", "en-us", "nl-nl", "pt-br", "zh-tw");
 
         mongodb = new MongoDB(Constants.DEVMODE ? getConfig().getString("mongodb.clienturi_dev") : getConfig().getString("mongodb.clienturi"), getConfig().getString("mongodb.database"));
         mysql = new MySQL(getConfig().getString("mysql.host"), getConfig().getString("mysql.port"), getConfig().getString("mysql.database"), getConfig().getString("mysql.username"), getConfig().getString("mysql.password"));

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -77,7 +77,7 @@ public class Main {
         });
 
         translationManager = new TranslationManager();
-        translationManager.loadTranslations("de-de", "en-us");
+        translationManager.loadTranslations("de-at", "de-de", "en-us");
 
         mongodb = new MongoDB(Constants.DEVMODE ? getConfig().getString("mongodb.clienturi_dev") : getConfig().getString("mongodb.clienturi"), getConfig().getString("mongodb.database"));
         mysql = new MySQL(getConfig().getString("mysql.host"), getConfig().getString("mysql.port"), getConfig().getString("mysql.database"), getConfig().getString("mysql.username"), getConfig().getString("mysql.password"));

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -77,7 +77,7 @@ public class Main {
         });
 
         translationManager = new TranslationManager();
-        translationManager.loadTranslations("de-at", "de-de", "en-us", "nl-nl", "pt-br", "zh-tw");
+        translationManager.loadTranslations("de-at", "de-de", "en-us", "fr-fr", "nl-nl", "pt-br", "zh-tw");
 
         mongodb = new MongoDB(Constants.DEVMODE ? getConfig().getString("mongodb.clienturi_dev") : getConfig().getString("mongodb.clienturi"), getConfig().getString("mongodb.database"));
         mysql = new MySQL(getConfig().getString("mysql.host"), getConfig().getString("mysql.port"), getConfig().getString("mysql.database"), getConfig().getString("mysql.username"), getConfig().getString("mysql.password"));

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -21,6 +21,7 @@ package de.fbrettnich.easypoll.core;
 import de.fbrettnich.easypoll.database.MongoDB;
 import de.fbrettnich.easypoll.database.MySQL;
 import de.fbrettnich.easypoll.files.ConfigFile;
+import de.fbrettnich.easypoll.language.TranslationManager;
 import de.fbrettnich.easypoll.listener.*;
 import de.fbrettnich.easypoll.timertasks.BotListStats;
 import de.fbrettnich.easypoll.timertasks.CloseTimedPolls;
@@ -54,6 +55,7 @@ public class Main {
     private static MongoDB mongodb;
     private static MySQL mysql;
     private static ShardManager shardManager;
+    private static TranslationManager translationManager;
 
     /**
      * The main method to build and start the bot
@@ -70,6 +72,9 @@ public class Main {
             options.setDsn(getConfig().getString("sentry.url"));
             options.setEnvironment(Constants.DEVMODE ? "development" : "production");
         });
+
+        translationManager = new TranslationManager();
+        translationManager.loadTranslations("de", "en");
 
         mongodb = new MongoDB(Constants.DEVMODE ? getConfig().getString("mongodb.clienturi_dev") : getConfig().getString("mongodb.clienturi"), getConfig().getString("mongodb.database"));
         mysql = new MySQL(getConfig().getString("mysql.host"), getConfig().getString("mysql.port"), getConfig().getString("mysql.database"), getConfig().getString("mysql.username"), getConfig().getString("mysql.password"));
@@ -332,5 +337,14 @@ public class Main {
      */
     public static ShardManager getShardManager() {
         return shardManager;
+    }
+
+    /**
+     * Get the TranslationManager
+     *
+     * @return {@link TranslationManager}
+     */
+    public static TranslationManager getTranslationManager() {
+        return translationManager;
     }
 }

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -96,6 +96,7 @@ public class Main {
                 .addEventListeners(new MessageReactionAddListener())
                 .addEventListeners(new MessageReceivedListener())
                 .addEventListeners(new ReadyListener())
+                .addEventListeners(new SelectionMenuListener())
                 .addEventListeners(new SlashCommandListener())
 
                 .setStatus(OnlineStatus.ONLINE);
@@ -299,6 +300,9 @@ public class Main {
                 )
                 .addCommands(
                         new CommandData("setup", "Bot setup and settings")
+                                .addSubcommands(
+                                        new SubcommandData("language", "Change the guild language")
+                                )
                                 .addSubcommands(
                                         new SubcommandData("permissions", "Check required bot permissions")
                                 )

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -77,7 +77,7 @@ public class Main {
         });
 
         translationManager = new TranslationManager();
-        translationManager.loadTranslations("de-at", "de-de", "en-us", "pt-br");
+        translationManager.loadTranslations("de-at", "de-de", "en-us", "nl-nl", "pt-br");
 
         mongodb = new MongoDB(Constants.DEVMODE ? getConfig().getString("mongodb.clienturi_dev") : getConfig().getString("mongodb.clienturi"), getConfig().getString("mongodb.database"));
         mysql = new MySQL(getConfig().getString("mysql.host"), getConfig().getString("mysql.port"), getConfig().getString("mysql.database"), getConfig().getString("mysql.username"), getConfig().getString("mysql.password"));

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -77,7 +77,7 @@ public class Main {
         });
 
         translationManager = new TranslationManager();
-        translationManager.loadTranslations("de-at", "de-de", "en-us");
+        translationManager.loadTranslations("de-at", "de-de", "en-us", "pt-br");
 
         mongodb = new MongoDB(Constants.DEVMODE ? getConfig().getString("mongodb.clienturi_dev") : getConfig().getString("mongodb.clienturi"), getConfig().getString("mongodb.database"));
         mysql = new MySQL(getConfig().getString("mysql.host"), getConfig().getString("mysql.port"), getConfig().getString("mysql.database"), getConfig().getString("mysql.username"), getConfig().getString("mysql.password"));

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -77,7 +77,7 @@ public class Main {
         });
 
         translationManager = new TranslationManager();
-        translationManager.loadTranslations("de", "en");
+        translationManager.loadTranslations("de-de", "en-us");
 
         mongodb = new MongoDB(Constants.DEVMODE ? getConfig().getString("mongodb.clienturi_dev") : getConfig().getString("mongodb.clienturi"), getConfig().getString("mongodb.database"));
         mysql = new MySQL(getConfig().getString("mysql.host"), getConfig().getString("mysql.port"), getConfig().getString("mysql.database"), getConfig().getString("mysql.username"), getConfig().getString("mysql.password"));

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -56,6 +57,8 @@ public class Main {
     private static MySQL mysql;
     private static ShardManager shardManager;
     private static TranslationManager translationManager;
+
+    public static HashMap<String, String> guildLanguageCache = new HashMap<>();
 
     /**
      * The main method to build and start the bot

--- a/src/main/java/de/fbrettnich/easypoll/language/GuildLanguage.java
+++ b/src/main/java/de/fbrettnich/easypoll/language/GuildLanguage.java
@@ -21,6 +21,7 @@ package de.fbrettnich.easypoll.language;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
+import de.fbrettnich.easypoll.core.Constants;
 import de.fbrettnich.easypoll.core.Main;
 import net.dv8tion.jda.api.entities.Guild;
 
@@ -82,7 +83,7 @@ public class GuildLanguage {
         DBObject searchQuery = new BasicDBObject("guildId", this.guildId);
         DBObject document = collection.findOne(searchQuery);
 
-        String lang = "en";
+        String lang = Constants.DEFAULT_LANGUAGE;
         if (document != null) {
             lang = (String) document.get("language");
         }

--- a/src/main/java/de/fbrettnich/easypoll/language/GuildLanguage.java
+++ b/src/main/java/de/fbrettnich/easypoll/language/GuildLanguage.java
@@ -1,0 +1,109 @@
+/*
+ * EasyPoll Discord Bot (https://github.com/fbrettnich/easypoll-bot)
+ * Copyright (C) 2021  Felix Brettnich
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.fbrettnich.easypoll.language;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import de.fbrettnich.easypoll.core.Main;
+import net.dv8tion.jda.api.entities.Guild;
+
+public class GuildLanguage {
+
+    private final String guildId;
+    private String language;
+
+    public GuildLanguage(String guildId) {
+        this.guildId = guildId;
+        this.language = getLanguage();
+    }
+
+    public GuildLanguage(Guild guild) {
+        this.guildId = guild.getId();
+        this.language = getLanguage();
+    }
+
+    /**
+     * Set guild language code
+     *
+     * @param lang language code
+     */
+    public void setLanguage(String lang) {
+
+        this.language = lang;
+        Main.guildLanguageCache.put(this.guildId, lang);
+
+        DBCollection collection = Main.getMongoDB().getCollection("guilds");
+        DBObject searchQuery = new BasicDBObject("guildId", this.guildId);
+        DBObject document = collection.findOne(searchQuery);
+
+        if(document == null) {
+            document = new BasicDBObject();
+
+            document.put("guildId", this.guildId);
+            document.put("language", lang);
+
+            collection.insert(document);
+        }else{
+            document.put("language", lang);
+
+            collection.update(searchQuery, document);
+        }
+    }
+
+    /**
+     * Get guild language code
+     *
+     * @return language code
+     */
+    public String getLanguage() {
+
+        if(Main.guildLanguageCache.containsKey(guildId)) {
+            return Main.guildLanguageCache.get(this.guildId);
+        }
+
+        DBCollection collection = Main.getMongoDB().getCollection("guilds");
+        DBObject searchQuery = new BasicDBObject("guildId", this.guildId);
+        DBObject document = collection.findOne(searchQuery);
+
+        String lang = "en";
+        if (document != null) {
+            lang = (String) document.get("language");
+        }
+
+        Main.guildLanguageCache.put(this.guildId, lang);
+        return lang;
+    }
+
+    /**
+     * Get translation in guild language
+     *
+     * @param key translation key
+     * @return translation
+     */
+    public String getTl(String key, String... placeholder) {
+        String translation = Main.getTranslationManager().getTranslation(this.language, key);
+
+        for (String s : placeholder) {
+            translation = translation.replaceFirst("%s", s);
+        }
+
+        return translation;
+    }
+}

--- a/src/main/java/de/fbrettnich/easypoll/language/TranslationManager.java
+++ b/src/main/java/de/fbrettnich/easypoll/language/TranslationManager.java
@@ -102,7 +102,6 @@ public class TranslationManager {
             String k = lang + ":" + pathKey;
             k = k.replaceFirst("\\.", "");
             translations.put(k, (String) obj);
-            System.out.println(k + " | " + obj);
         }
     }
 

--- a/src/main/java/de/fbrettnich/easypoll/language/TranslationManager.java
+++ b/src/main/java/de/fbrettnich/easypoll/language/TranslationManager.java
@@ -1,0 +1,132 @@
+/*
+ * EasyPoll Discord Bot (https://github.com/fbrettnich/easypoll-bot)
+ * Copyright (C) 2021  Felix Brettnich
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.fbrettnich.easypoll.language;
+
+import io.sentry.Sentry;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class TranslationManager {
+
+    private final ArrayList<String> languages = new ArrayList<>();
+    private final HashMap<String, String> translations = new HashMap<>();
+
+    public TranslationManager() { }
+
+    /**
+     * Load multiple translations
+     *
+     * @param countryCodes country code list
+     */
+    public void loadTranslations(String... countryCodes) {
+        for (String countryCode : countryCodes) {
+            loadTranslation(countryCode);
+        }
+    }
+
+    /**
+     * Load a translation
+     *
+     * @param countryCode country code
+     */
+    public void loadTranslation(String countryCode) {
+        languages.add(countryCode);
+
+        JSONParser parser = new JSONParser();
+        InputStream inputStream = TranslationManager.class.getResourceAsStream("/translations/" + countryCode + ".json");
+
+        try {
+            Object obj = parser.parse(inputStreamToString(inputStream));
+            JSONObject jsonObject = (JSONObject) obj;
+            jsonObject.forEach((key, value) -> addTranslation(countryCode, "", key, value));
+        } catch (Exception e) {
+            Sentry.captureException(e);
+        }
+    }
+
+    /**
+     * Read an InputStream and convert it to a String
+     *
+     * @param stream {@link InputStream}
+     * @return {@link InputStream} as {@link String}
+     * @throws IOException
+     */
+    private String inputStreamToString(InputStream stream) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        InputStreamReader isr = new InputStreamReader(stream, StandardCharsets.UTF_8);
+        BufferedReader br = new BufferedReader(isr);
+
+        String read;
+        while((read = br.readLine()) != null) {
+            sb.append(read);
+        }
+        br.close();
+
+        return sb.toString();
+    }
+
+    /**
+     * Load a translation path
+     *
+     * @param lang country code
+     * @param path translation path
+     * @param key translation path key
+     * @param obj translation object
+     */
+    private void addTranslation(String lang, String path, Object key, Object obj) {
+        String pathKey = path + "." + key;
+        if(obj instanceof JSONObject) {
+            ((JSONObject) obj).forEach((o, o2) -> addTranslation(lang, pathKey, o, o2));
+        }else{
+            String k = lang + ":" + pathKey;
+            k = k.replaceFirst("\\.", "");
+            translations.put(k, (String) obj);
+            System.out.println(k + " | " + obj);
+        }
+    }
+
+    /**
+     * Get a translation
+     *
+     * @param lang country code
+     * @param key translation path key
+     * @return translation
+     */
+    public String getTranslation(String lang, String key) {
+        if (translations.containsKey(lang + ":" + key)) {
+            return translations.get(lang + ":" + key);
+        }else {
+            return translations.getOrDefault("en:" + key, "[Empty translation " + key + "]");
+        }
+    }
+
+    /**
+     * Get loaded languages code list
+     *
+     * @return languages
+     */
+    public ArrayList<String> getLanguages() {
+        return languages;
+    }
+}

--- a/src/main/java/de/fbrettnich/easypoll/listener/SelectionMenuListener.java
+++ b/src/main/java/de/fbrettnich/easypoll/listener/SelectionMenuListener.java
@@ -1,0 +1,50 @@
+/*
+ * EasyPoll Discord Bot (https://github.com/fbrettnich/easypoll-bot)
+ * Copyright (C) 2021  Felix Brettnich
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.fbrettnich.easypoll.listener;
+
+import de.fbrettnich.easypoll.language.GuildLanguage;
+import de.fbrettnich.easypoll.selectionmenus.ChangeLanguageMenu;
+import io.sentry.Sentry;
+import io.sentry.SentryLevel;
+import net.dv8tion.jda.api.events.interaction.SelectionMenuEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+public class SelectionMenuListener extends ListenerAdapter {
+
+    @Override
+    public void onSelectionMenu(SelectionMenuEvent event) {
+
+        if(event.getGuild() == null) return;
+
+        GuildLanguage gl = new GuildLanguage(event.getGuild());
+
+        String componentId = event.getComponentId();
+
+        switch (componentId) {
+            case "ChangeLanguageMenu":
+                new ChangeLanguageMenu(event, gl);
+                break;
+
+            default:
+                event.reply("Sorry! I cannot process this selection.").queue(null, Sentry::captureException);
+                Sentry.captureMessage("Cannot process selection: " + componentId, SentryLevel.ERROR);
+                break;
+        }
+    }
+}

--- a/src/main/java/de/fbrettnich/easypoll/listener/SlashCommandListener.java
+++ b/src/main/java/de/fbrettnich/easypoll/listener/SlashCommandListener.java
@@ -19,6 +19,7 @@
 package de.fbrettnich.easypoll.listener;
 
 import de.fbrettnich.easypoll.commands.*;
+import de.fbrettnich.easypoll.language.GuildLanguage;
 import de.fbrettnich.easypoll.utils.Statistics;
 import de.fbrettnich.easypoll.utils.enums.StatisticsCommands;
 import io.sentry.Sentry;
@@ -33,43 +34,45 @@ public class SlashCommandListener  extends ListenerAdapter {
 
         if(event.getGuild() == null) return;
 
+        GuildLanguage gl = new GuildLanguage(event.getGuild());
+
         String commandName = event.getName();
         String subCommandName = event.getSubcommandName();
 
         switch (commandName) {
             case "closepoll":
-                new ClosePollCommand(event);
+                new ClosePollCommand(event, gl);
                 Statistics.insertCommandUsage(StatisticsCommands.SLASH_CLOSEPOLL);
                 break;
 
             case "help":
             case "easypoll":
-                new HelpCommand(event);
+                new HelpCommand(event, gl);
                 Statistics.insertCommandUsage(StatisticsCommands.SLASH_HELP);
                 break;
 
             case "info":
-                new InfoCommand(event);
+                new InfoCommand(event, gl);
                 Statistics.insertCommandUsage(StatisticsCommands.SLASH_INFO);
                 break;
 
             case "invite":
-                new InviteCommand(event);
+                new InviteCommand(event, gl);
                 Statistics.insertCommandUsage(StatisticsCommands.SLASH_INVITE);
                 break;
 
             case "ping":
-                new PingCommand(event);
+                new PingCommand(event, gl);
                 Statistics.insertCommandUsage(StatisticsCommands.SLASH_PING);
                 break;
 
             case "poll":
-                new PollCommand(event, false);
+                new PollCommand(event, gl, false);
                 Statistics.insertCommandUsage(StatisticsCommands.SLASH_POLL);
                 break;
 
             case "timepoll":
-                new PollCommand(event, true);
+                new PollCommand(event, gl, true);
                 Statistics.insertCommandUsage(StatisticsCommands.SLASH_TIMEPOLL);
                 break;
 
@@ -77,13 +80,13 @@ public class SlashCommandListener  extends ListenerAdapter {
                 if(subCommandName == null) break;
                 switch (subCommandName) {
                     case "permissions":
-                        new SetupPermissionsCommand(event);
+                        new SetupPermissionsCommand(event, gl);
                         break;
                 }
                 break;
 
             case "vote":
-                new VoteCommand(event);
+                new VoteCommand(event, gl);
                 Statistics.insertCommandUsage(StatisticsCommands.SLASH_VOTE);
                 break;
 

--- a/src/main/java/de/fbrettnich/easypoll/listener/SlashCommandListener.java
+++ b/src/main/java/de/fbrettnich/easypoll/listener/SlashCommandListener.java
@@ -79,6 +79,9 @@ public class SlashCommandListener  extends ListenerAdapter {
             case "setup":
                 if(subCommandName == null) break;
                 switch (subCommandName) {
+                    case "language":
+                        new SetupLanguageCommand(event, gl);
+                        break;
                     case "permissions":
                         new SetupPermissionsCommand(event, gl);
                         break;

--- a/src/main/java/de/fbrettnich/easypoll/selectionmenus/ChangeLanguageMenu.java
+++ b/src/main/java/de/fbrettnich/easypoll/selectionmenus/ChangeLanguageMenu.java
@@ -1,0 +1,108 @@
+/*
+ * EasyPoll Discord Bot (https://github.com/fbrettnich/easypoll-bot)
+ * Copyright (C) 2021  Felix Brettnich
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.fbrettnich.easypoll.selectionmenus;
+
+import de.fbrettnich.easypoll.core.Constants;
+import de.fbrettnich.easypoll.language.GuildLanguage;
+import io.sentry.Sentry;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.SelectionMenuEvent;
+import net.dv8tion.jda.api.exceptions.ErrorHandler;
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
+import net.dv8tion.jda.api.requests.ErrorResponse;
+
+import javax.annotation.Nonnull;
+import java.awt.*;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+public class ChangeLanguageMenu {
+
+    public ChangeLanguageMenu(@Nonnull SelectionMenuEvent event, GuildLanguage gl) {
+
+        event.deferReply().queue(null, Sentry::captureException);
+
+        InteractionHook hook = event.getHook();
+        User user = event.getUser();
+        Member member = event.getMember();
+        Message message = event.getMessage();
+        List<SelectOption> selectOptions = event.getSelectedOptions();
+
+        if(member == null) return;
+        if(selectOptions == null) return;
+
+        if(
+                !member.isOwner() &&
+                !member.hasPermission(Permission.ADMINISTRATOR) &&
+                !member.hasPermission(Permission.MANAGE_PERMISSIONS)
+        )
+        {
+
+            EmbedBuilder eb = new EmbedBuilder();
+
+            eb.setColor(Color.RED);
+            eb.setTitle(gl.getTl("errors.no_permissions.member.title"), Constants.WEBSITE_URL);
+            eb.addField(
+                    gl.getTl("errors.no_permissions.member.field.title"),
+                    "\u2022 ADMINISTRATOR *(Permission)*\n" +
+                            "\u2022 MANAGE_PERMISSIONS *(Permission)*",
+                    true);
+
+            hook.sendMessageEmbeds(
+                            eb.build()
+                    )
+                    .delay(30, TimeUnit.SECONDS)
+                    .flatMap(Message::delete)
+                    .queue(null, new ErrorHandler()
+                            .ignore(ErrorResponse.UNKNOWN_MESSAGE)
+                            .handle(Objects::nonNull, Sentry::captureException)
+                    );
+
+            return;
+        }
+
+        if(message != null) {
+            message.delete().queue(null, Sentry::captureException);
+        }
+
+        String lang = "en";
+        if(!selectOptions.isEmpty()) {
+            lang = selectOptions.get(0).getValue();
+        }
+
+        gl.setLanguage(lang);
+
+        EmbedBuilder eb = new EmbedBuilder();
+
+        eb.setTitle(gl.getTl("commands.setup.language.success.title"), Constants.WEBSITE_URL);
+        eb.setColor(Color.decode("#01FF70"));
+        eb.setDescription(gl.getTl("commands.setup.language.success.description", gl.getTl("translation.name_local")));
+        eb.setFooter(gl.getTl("commands.setup.language.success.footer", (user.getName() + "#" + user.getDiscriminator())));
+
+        hook.sendMessageEmbeds(
+                eb.build()
+        ).queue(null, Sentry::captureException);
+    }
+}

--- a/src/main/java/de/fbrettnich/easypoll/selectionmenus/ChangeLanguageMenu.java
+++ b/src/main/java/de/fbrettnich/easypoll/selectionmenus/ChangeLanguageMenu.java
@@ -87,7 +87,7 @@ public class ChangeLanguageMenu {
             message.delete().queue(null, Sentry::captureException);
         }
 
-        String lang = "en";
+        String lang = Constants.DEFAULT_LANGUAGE;
         if(!selectOptions.isEmpty()) {
             lang = selectOptions.get(0).getValue();
         }

--- a/src/main/java/de/fbrettnich/easypoll/utils/PollManager.java
+++ b/src/main/java/de/fbrettnich/easypoll/utils/PollManager.java
@@ -24,6 +24,7 @@ import com.mongodb.DBObject;
 import com.mongodb.lang.Nullable;
 import de.fbrettnich.easypoll.core.Constants;
 import de.fbrettnich.easypoll.core.Main;
+import de.fbrettnich.easypoll.language.GuildLanguage;
 import de.fbrettnich.easypoll.utils.enums.PollType;
 import io.sentry.Sentry;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -51,25 +52,34 @@ public class PollManager {
      * @param question Poll question
      * @param choicesReaction Reaction list of the answers
      * @param choicesContent Text list of the answers
+     * @param gl {@link GuildLanguage} Guild language manager
      * @return The full and complete message embed
      */
-    public MessageEmbed getPollEmbed(String pollId, PollType pollType, long endTime, Boolean closed, @Nullable List<MessageReaction> messageReactions, @Nullable Boolean allowmultiplechoices, String question, List<String> choicesReaction, List<String> choicesContent) {
+    public MessageEmbed getPollEmbed(String pollId, PollType pollType, long endTime, Boolean closed, @Nullable List<MessageReaction> messageReactions, @Nullable Boolean allowmultiplechoices, String question, List<String> choicesReaction, List<String> choicesContent, GuildLanguage gl) {
 
         EmbedBuilder eb = new EmbedBuilder();
         StringBuilder description = new StringBuilder();
 
         description
-                .append("**Question**\n")
+                .append("**")
+                .append(gl.getTl("polls.question"))
+                .append("**\n")
                 .append(question)
                 .append("\n")
                 .append("\n")
-                .append("**Choices**\n");
+                .append("**")
+                .append(gl.getTl("polls.choices"))
+                .append("**\n");
 
         if (pollType == PollType.DEFAULT_UPDOWN || pollType == PollType.TIME_UPDOWN) {
             eb.setColor(Constants.COLOR_POLL_UPDOWN);
             description
-                    .append(":thumbsup: Yes\n")
-                    .append(":thumbsdown: No\n");
+                    .append(":thumbsup: ")
+                    .append(gl.getTl("polls.yes"))
+                    .append("\n")
+                    .append(":thumbsdown: ")
+                    .append(gl.getTl("polls.no"))
+                    .append("\n");
         } else {
             for (int i = 0; i < choicesReaction.size(); i++) {
                 description
@@ -92,7 +102,10 @@ public class PollManager {
 
             if(messageReactions.size() >= choicesReaction.size()) {
 
-                description.append("\n**Final Result**\n");
+                description
+                        .append("\n**")
+                        .append(gl.getTl("polls.finalresult"))
+                        .append("**\n");
 
                 for (int i = 0; i < choicesReaction.size(); i++) {
 
@@ -115,11 +128,14 @@ public class PollManager {
 
         if (pollType == PollType.TIME_UPDOWN || pollType == PollType.TIME_MULTI) {
             if(closed) {
-                description
-                        .append("\n:alarm_clock: Poll already ended");
+                description.
+                        append("\n:alarm_clock: ")
+                        .append(gl.getTl("polls.alreadyended"));
             }else{
                 description
-                        .append("\n:alarm_clock: Ends ")
+                        .append("\n:alarm_clock: ")
+                        .append(gl.getTl("polls.ends"))
+                        .append(" ")
                         .append("<t:")
                         .append(endTime / 1000L)
                         .append(":R>");
@@ -127,19 +143,25 @@ public class PollManager {
         }
 
         if (allowmultiplechoices != null && allowmultiplechoices) {
-            description.append("\n:white_check_mark: Multiple choices allowed");
+            description
+                    .append("\n:white_check_mark: ")
+                    .append(gl.getTl("polls.multiplechoice.allowed"));
         } else {
-            description.append("\n:no_entry: Multiple choices not allowed");
+            description
+                    .append("\n:no_entry: ")
+                    .append(gl.getTl("polls.multiplechoice.disallowed"));
         }
 
         if(closed) {
             eb.setColor(Constants.COLOR_POLL_CLOSED);
-            description.append("\n:lock: No other votes allowed");
+            description
+                    .append("\n:lock: ")
+                    .append(gl.getTl("polls.noothervotes"));
         }
 
         eb.setDescription(description);
 
-        eb.setFooter("Poll ID: " + pollId);
+        eb.setFooter(gl.getTl("polls.pollid", pollId));
 
         return eb.build();
     }
@@ -248,7 +270,8 @@ public class PollManager {
                                                     (boolean) document.get("multiplechoices"),
                                                     (String) document.get("question"),
                                                     (List<String>) document.get("choices_reaction"),
-                                                    (List<String>) document.get("choices_content")
+                                                    (List<String>) document.get("choices_content"),
+                                                    new GuildLanguage((String) document.get("guildId"))
                                             )
                                     ).queue(null, Sentry::captureException);
                                 } catch (InsufficientPermissionException ignored) {}

--- a/src/main/resources/translations/de-at.json
+++ b/src/main/resources/translations/de-at.json
@@ -1,0 +1,146 @@
+{
+  "translation": {
+    "name": "German-Austrian",
+    "name_local": "Östareichisch",
+    "code": "at",
+    "flag_unicode": "\uD83C\uDDE6\uD83C\uDDF9",
+    "translators": "Lukaѕ#9999 (630816377183141928)"
+  },
+  "polls": {
+    "question": "Frogn",
+    "choices": "Auswoimöglichkeitn",
+    "yes": "Joa",
+    "no": "Na",
+    "finalresult": "Endgültigs Ergebnis",
+    "alreadyended": "De Umfrog is scho zuar",
+    "ends": "Endet",
+    "multiplechoice": {
+      "allowed": "De mehrfoche Auswoi is möglich",
+      "disallowed": "De mehrfoche Auswoi is vaboten"
+    },
+    "noothervotes": "Kane weidan Stimmen kinan ogeben werdn",
+    "pollid": "Umfrogn ID: %s"
+  },
+  "commands": {
+    "closepoll": {
+      "success": {
+        "title": "De Umfrog is erfoigreich gschlossa wordn",
+        "description": "De Umfrog mit da ID **%s** is scho zuar!\nEs sand kane weidaren Stimma erlaubt und's Ergebnis wird in da Umfrog ozagt."
+      },
+      "failed": {
+        "title": "De Umfrog ko ned zuagmocht werdan",
+        "description": "De Umfrog mit da ID **%s** is scho zuar oda gibts ned amoi!"
+      }
+    },
+    "help": {
+      "title": "EasyPoll Hüfn",
+      "fields": {
+        "poll_commands": {
+          "title": ":bar_chart: Umfrogn-Befehle",
+          "commands": {
+            "poll": "Erstö a normale Umfrog ohne des Zeitlimit",
+            "timepoll": "Erstö a zeitlich begrenzte Umfrog, leg a Enddatum fest, bis zu wöcham de Umfrog vafügba sa soid",
+            "closepoll": "A Umfrog zuarmocha, damid kane weidaren Stimma zöd werdan"
+          }
+        },
+        "public_commands": {
+          "title": ":mag_right: Öffentliche Befehle",
+          "commands": {
+            "help": "Zagt de Bot-Hüfn hier o",
+            "vote": "Stimm für n EasyPoll-Bot ab",
+            "invite": "Lod EasyPoll auf dein eigenen Discord ei",
+            "info": "Zag a poar Infos üba EasyPoll",
+            "ping": "Guck den Ping fum Bot zum Discord-Gateway o"
+          }
+        }
+      }
+    },
+    "info": {
+      "title": "EasyPoll Informationen",
+      "fields": {
+        "creator": "Entwickla",
+        "repository": "Repository",
+        "version": "Version",
+        "library": "Library",
+        "servers": "Serva",
+        "users": "Benutza",
+        "shard": "Shard",
+        "uptime": "Uptime"
+      }
+    },
+    "invite": {
+      "title": "Eiloda fu EasyPoll",
+      "description": "Du kost %s hier eiloda: [www.easypoll.me/invite](%s)"
+    },
+    "ping": {
+      "title": "Pong! :ping_pong:",
+      "description": "`Ping zum Gateway %s ms`"
+    },
+    "poll": {
+      "invalid_time": {
+        "title": "Ungültige Zeitogob!",
+        "field": {
+          "title": "Do host a ungültige Zeit eigeban!",
+          "description": "Vawend am Ende ana Zoi s (Sekunde), m (Minute), h (Stunde), d (Tag) oder w (Woche) für de Zeitogob.\nBeispiele: 15m für 15 Minutn, 1h für 1 Stunde, 3d für 3 Tage\n\n*PS: Klick aufn blauen`/timepoll` Befehl übda der Nochricht do, um a Kopie des Befehls für dei Umfrog zu erhoitn.*"
+        }
+      },
+      "unknown_emoji": {
+        "title": "Des Emoji gibts ned",
+        "field": {
+          "title": "Do host a ned existirandes Emoji ogeben!",
+          "description": "Bitte pass drauf auf, dass es a **offizielles Discord** Emoji oda a Emoji **fu dem Server hier** is. EasyPoll kann nur Emojis fu den Servan vawenda, auf de wos sie da Bot a befindet.\n\n*PS: Klicke auf den blauen `%s` Befehl über dieser Nachricht, um eine Kopie des Befehls deiner Umfrage zu erhalten.*"
+        }
+      }
+    },
+    "setup": {
+      "language": {
+        "change": {
+          "title": "Bot-Sprochn ändan",
+          "description": "Hier koste de Sproch fum Bot für dein Serva ändan.\nSuach da de neiche Sprochn aus:",
+          "selectionmenu": {
+            "placeholder": "Suach da a Sproch aus.."
+          }
+        },
+        "success": {
+          "title": "De Sprochn fum Bot wurde geändat",
+          "description": "De Bot-Sprochn wurde für den Serva erfolgreich auf **%s** geändat.",
+          "footer": "Geändat fu %s"
+        }
+      },
+      "permissions": {
+        "title": "Prüfen fu de Rechte vum Bot",
+        "server_permissions": "Serva-Rechte",
+        "channel_permissions": "Kanal-Rechte",
+        "permissions": {
+          "message_read": "Nochrichten lesa",
+          "message_write": "Nochrichten vaschicka",
+          "message_manage": "Nochrichten verwalta",
+          "message_embed_links": "Links eibettan",
+          "message_history": "Nochrichtnverlauf ozang",
+          "message_add_reaction": "Reaktionen dazurgeben",
+          "message_ext_emoji": "Externe Emojis vawendan"
+        }
+      }
+    },
+    "vote": {
+      "title": "Obstimma für EasyPoll",
+      "description": "Wir gfrein uns, daste für den Bot stimma wüst. Du zagst uns, dass du in Bot mogst und hüfst uns, weida zu wochsan.\n\nAuf den foigenden Seiten konste für uns obstimma:"
+    }
+  },
+  "errors": {
+    "no_permissions": {
+      "member": {
+        "title": "Du host ned die Berechtigung um den Befehl zu nutza!",
+        "field": {
+          "title": "Um den Befehl zu nutza, brauchste ans fu denen:"
+        }
+      },
+      "bot": {
+        "title": "I hob leida ned de nötigen Rechte um olle Aktionen zu mocha!",
+        "field": {
+          "title": "Bitte pass auf, dass ich foigende Rechte hob:"
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/translations/de-at.json
+++ b/src/main/resources/translations/de-at.json
@@ -1,6 +1,6 @@
 {
   "translation": {
-    "name": "German-Austrian",
+    "name": "German (Austrian)",
     "name_local": "Östareichisch",
     "code": "de-at",
     "flag_unicode": "\uD83C\uDDE6\uD83C\uDDF9",

--- a/src/main/resources/translations/de-at.json
+++ b/src/main/resources/translations/de-at.json
@@ -2,7 +2,7 @@
   "translation": {
     "name": "German-Austrian",
     "name_local": "Östareichisch",
-    "code": "at",
+    "code": "de-at",
     "flag_unicode": "\uD83C\uDDE6\uD83C\uDDF9",
     "translators": "Lukaѕ#9999 (630816377183141928)"
   },

--- a/src/main/resources/translations/de-de.json
+++ b/src/main/resources/translations/de-de.json
@@ -2,7 +2,7 @@
   "translation": {
     "name": "German",
     "name_local": "Deutsch",
-    "code": "de",
+    "code": "de-de",
     "flag_unicode": "\uD83C\uDDE9\uD83C\uDDEA",
     "translators": "Floxiii#0001 (231091710195662848)"
   },

--- a/src/main/resources/translations/de-de.json
+++ b/src/main/resources/translations/de-de.json
@@ -3,7 +3,8 @@
     "name": "German",
     "name_local": "Deutsch",
     "code": "de",
-    "flag_unicode": "\uD83C\uDDE9\uD83C\uDDEA"
+    "flag_unicode": "\uD83C\uDDE9\uD83C\uDDEA",
+    "translators": "Floxiii#0001 (231091710195662848)"
   },
   "polls": {
     "question": "Frage",

--- a/src/main/resources/translations/de.json
+++ b/src/main/resources/translations/de.json
@@ -1,0 +1,138 @@
+{
+  "translation": {
+    "name": "German",
+    "name_local": "Deutsch",
+    "code": "de",
+    "flag_unicode": "\uD83C\uDDE9\uD83C\uDDEA"
+  },
+  "polls": {
+    "question": "Frage",
+    "choices": "Auswahlmöglichkeiten",
+    "yes": "Ja",
+    "no": "Nein",
+    "finalresult": "Endgültiges Ergebnis",
+    "alreadyended": "Umfrage bereits beendet",
+    "ends": "Endet",
+    "multiplechoice": {
+      "allowed": "Mehrfachauswahl erlaubt",
+      "disallowed": "Mehrfachauswahl verboten"
+    },
+    "noothervotes": "Keine weiteren Stimmen erlaubt",
+    "pollid": "Poll ID: %s"
+  },
+  "commands": {
+    "closepoll": {
+      "success": {
+        "title": "Umfrage geschlossen",
+        "description": "Die Umfrage mit der ID **%s** wurde geschlossen!\nEs sind keine weiteren Stimmen mehr erlaubt und das Ergebnis wird nun in der Umfrage angezeigt."
+      },
+      "failed": {
+        "title": "Umfrage kann nicht geschlossen werden",
+        "description": "Die Umfrage mit der ID **%s** wurde bereits geschlossen oder existiert nicht!"
+      }
+    },
+    "help": {
+      "title": "EasyPoll Hilfe",
+      "fields": {
+        "poll_commands": {
+          "title": ":bar_chart: Umfrage Befehle",
+          "commands": {
+            "poll": "Erstelle eine normale Umfrage ohne Zeitlimit",
+            "timepoll": "Erstelle eine zeitlich begrenzte Umfrage, lege ein Enddatum fest, bis zu dem die Umfrage laufen soll",
+            "closepoll": "Eine Umfrage schließen, damit keine weiteren Stimmen gezählt werden"
+          }
+        },
+        "public_commands": {
+          "title": ":mag_right: Öffentliche Befehle",
+          "commands": {
+            "help": "Zeige diese Bot Hilfe",
+            "vote": "Stimme für den EasyPoll Bot ab",
+            "invite": "Lade EasyPoll auf deinen eigenen Discord Server ein",
+            "info": "Zeige einige Informationen über EasyPoll",
+            "ping": "Sehen den Ping des Bots zum Discord Gateway"
+          }
+        }
+      }
+    },
+    "info": {
+      "title": "EasyPoll Information",
+      "fields": {
+        "creator": "Entwickler",
+        "repository": "Repository",
+        "version": "Version",
+        "library": "Library",
+        "servers": "Server",
+        "users": "User",
+        "shard": "Shard",
+        "uptime": "Uptime"
+      }
+    },
+    "invite": {
+      "title": "Einladen von EasyPoll",
+      "description": "Du kannst %s hier einladen: [www.easypoll.me/invite](%s)"
+    },
+    "ping": {
+      "title": "Pong! :ping_pong:",
+      "description": "`Ping zum Gateway %s ms`"
+    },
+    "poll": {
+      "invalid_time": {
+        "title": "Ungültige Zeitangabe!",
+        "field": {
+          "title": "Du hast eine ungültige Zeit eingegeben!",
+          "description": "Verwende am Ende einer Zahl s (Sekunde), m (Minute), h (Stunde), d (Tag) oder w (Woche) für Zeitangaben.\nBeispiele: 15m für 15 Minuten, 1h für 1 Stunde, 3d für 3 Tage\n\n*PS: Du findest den von dir gesendeten Befehl, dieser Umfrage, zum Kopieren als Nachricht, auf die ich geantwortet habe (Klicke auf den blauen `/timepoll` Befehl über dieser Meldung)*"
+        }
+      },
+      "unknown_emoji": {
+        "title": "Unbekanntes Emoji",
+        "field": {
+          "title": "Du hast ein unbekanntes Emoji angegeben!",
+          "description": "Bitte achte darauf, dass es ein **offizielles Discord** Emoji oder ein Emoji **von diesem Server** ist. EasyPoll kann nur Emojis von Servern verwenden, auf denen sich EasyPoll ebenfalls befindet.\n\n*PS: Du findest den von dir gesendeten Befehl, dieser Umfrage, zum Kopieren als Nachricht, auf die ich geantwortet habe (Klicke auf den blauen `%s` Befehl über dieser Meldung)*"
+        }
+      }
+    },
+    "setup": {
+      "language": {
+        "title": "Bot Sprache ändern",
+        "description": "Hier kannst du die Bot Sprache auf diesem Server ändern.\nBitte wähle eine neue Sprache:",
+        "selectionmenu": {
+          "placeholder": "Wähle eine Sprache.."
+        }
+      },
+      "permissions": {
+        "title": "Prüfen der erforderlichen Bot Permissions",
+        "server_permissions": "Server Rechte",
+        "channel_permissions": "Channel Rechte",
+        "permissions": {
+          "message_read": "Nachrichten lesen",
+          "message_write": "Nachrichten senden",
+          "message_manage": "Nachrichten verwalten",
+          "message_embed_links": "Links einbetten",
+          "message_history": "Nachrichtenverlauf anzeigen",
+          "message_add_reaction": "Reaktionen hinzufügen",
+          "message_ext_emoji": "Externe Emojis verwenden"
+        }
+      }
+    },
+    "vote": {
+      "title": "Abstimmen für EasyPoll",
+      "description": "Wir freuen uns, dass du für unseren Bot stimmen möchtest. Du zeigst uns, dass du den Bot magst und hilfst uns, weiter zu wachsen.\n\nAuf den folgenden Seiten kannst du für uns abstimmen:"
+    }
+  },
+  "errors": {
+    "no_permissions": {
+      "member": {
+        "title": "Du hast keine Berechtigung, diesen Befehl zu benutzen!",
+        "field": {
+          "title": "Um diesen Befehl zu verwenden, benötigst du mindestens eins von diesen:"
+        }
+      },
+      "bot": {
+        "title": "Ich habe nicht die benötigten Berechtigungen, um alle Aktionen durchzuführen!",
+        "field": {
+          "title": "Bitte stelle sicher, dass ich die folgenden Berechtigungen habe:"
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/translations/de.json
+++ b/src/main/resources/translations/de.json
@@ -93,10 +93,17 @@
     },
     "setup": {
       "language": {
-        "title": "Bot Sprache ändern",
-        "description": "Hier kannst du die Bot Sprache auf diesem Server ändern.\nBitte wähle eine neue Sprache:",
-        "selectionmenu": {
-          "placeholder": "Wähle eine Sprache.."
+        "change": {
+          "title": "Bot Sprache ändern",
+          "description": "Hier kannst du die Bot Sprache auf diesem Server ändern.\nBitte wähle eine neue Sprache:",
+          "selectionmenu": {
+            "placeholder": "Wähle eine Sprache.."
+          }
+        },
+        "success": {
+          "title": "Bot Sprache wurde geändert",
+          "description": "Die Bot Sprache auf diesem Server wurde erfolgreich auf **%s** geändert.",
+          "footer": "Geändert von %s"
         }
       },
       "permissions": {

--- a/src/main/resources/translations/de.json
+++ b/src/main/resources/translations/de.json
@@ -49,7 +49,7 @@
             "vote": "Stimme für den EasyPoll Bot ab",
             "invite": "Lade EasyPoll auf deinen eigenen Discord Server ein",
             "info": "Zeige einige Informationen über EasyPoll",
-            "ping": "Sehen den Ping des Bots zum Discord Gateway"
+            "ping": "Sehe den Ping des Bots zum Discord Gateway"
           }
         }
       }
@@ -80,14 +80,14 @@
         "title": "Ungültige Zeitangabe!",
         "field": {
           "title": "Du hast eine ungültige Zeit eingegeben!",
-          "description": "Verwende am Ende einer Zahl s (Sekunde), m (Minute), h (Stunde), d (Tag) oder w (Woche) für Zeitangaben.\nBeispiele: 15m für 15 Minuten, 1h für 1 Stunde, 3d für 3 Tage\n\n*PS: Du findest den von dir gesendeten Befehl, dieser Umfrage, zum Kopieren als Nachricht, auf die ich geantwortet habe (Klicke auf den blauen `/timepoll` Befehl über dieser Meldung)*"
+          "description": "Verwende am Ende einer Zahl s (Sekunde), m (Minute), h (Stunde), d (Tag) oder w (Woche) für Zeitangaben.\nBeispiele: 15m für 15 Minuten, 1h für 1 Stunde, 3d für 3 Tage\n\n*PS: Klicke auf den blauen `/timepoll` Befehl über dieser Nachricht, um eine Kopie des Befehls deiner Umfrage zu erhalten.*"
         }
       },
       "unknown_emoji": {
         "title": "Unbekanntes Emoji",
         "field": {
           "title": "Du hast ein unbekanntes Emoji angegeben!",
-          "description": "Bitte achte darauf, dass es ein **offizielles Discord** Emoji oder ein Emoji **von diesem Server** ist. EasyPoll kann nur Emojis von Servern verwenden, auf denen sich EasyPoll ebenfalls befindet.\n\n*PS: Du findest den von dir gesendeten Befehl, dieser Umfrage, zum Kopieren als Nachricht, auf die ich geantwortet habe (Klicke auf den blauen `%s` Befehl über dieser Meldung)*"
+          "description": "Bitte achte darauf, dass es ein **offizielles Discord** Emoji oder ein Emoji **von diesem Server** ist. EasyPoll kann nur Emojis von Servern verwenden, auf denen sich EasyPoll ebenfalls befindet.\n\n*PS: Klicke auf den blauen `%s` Befehl über dieser Nachricht, um eine Kopie des Befehls deiner Umfrage zu erhalten.*"
         }
       }
     },

--- a/src/main/resources/translations/en-us.json
+++ b/src/main/resources/translations/en-us.json
@@ -1,6 +1,6 @@
 {
   "translation": {
-    "name": "English",
+    "name": "English (US)",
     "name_local": "English",
     "code": "en-us",
     "flag_unicode": "\uD83C\uDDFA\uD83C\uDDF8",

--- a/src/main/resources/translations/en-us.json
+++ b/src/main/resources/translations/en-us.json
@@ -2,7 +2,7 @@
   "translation": {
     "name": "English",
     "name_local": "English",
-    "code": "en",
+    "code": "en-us",
     "flag_unicode": "\uD83C\uDDFA\uD83C\uDDF8",
     "translators": "Floxiii#0001 (231091710195662848)"
   },

--- a/src/main/resources/translations/en-us.json
+++ b/src/main/resources/translations/en-us.json
@@ -3,7 +3,8 @@
     "name": "English",
     "name_local": "English",
     "code": "en",
-    "flag_unicode": "\uD83C\uDDFA\uD83C\uDDF8"
+    "flag_unicode": "\uD83C\uDDFA\uD83C\uDDF8",
+    "translators": "Floxiii#0001 (231091710195662848)"
   },
   "polls": {
     "question": "Question",

--- a/src/main/resources/translations/en.json
+++ b/src/main/resources/translations/en.json
@@ -80,14 +80,14 @@
         "title": "Invalid time specification!",
         "field": {
           "title": "You have entered an invalid time!",
-          "description": "Use at the end of a number s (second), m (minute), h (hour), d (day) or w (week) for time specifications.\nExamples: 15m for 15 minutes, 1h for 1 hour, 3d for 3 days\n\n*PS: You will find your sent command of this poll to copy as a message to which I replied (click on the blue `/timepoll` command above this message)*"
+          "description": "Use at the end of a number s (second), m (minute), h (hour), d (day) or w (week) for time specifications.\nExamples: 15m for 15 minutes, 1h for 1 hour, 3d for 3 days\n\n*PS: You can click on the blue `/timepoll` command above this message to receive a copy of the used command for your poll*"
         }
       },
       "unknown_emoji": {
         "title": "Unknown Emoji",
         "field": {
           "title": "You have specified an unknown emoji!",
-          "description": "Please make sure it is an **official Discord** emoji or an emoji **from this server**. EasyPoll can only use emojis from servers where EasyPoll is too.\n\n*PS: You will find your sent command of this poll to copy as a message to which I replied (click on the blue `%s` command above this message)*"
+          "description": "Please make sure it is an **official Discord** emoji or an emoji **from this server**. EasyPoll can only use emojis from servers where EasyPoll is too.\n\n*PS: You can click on the blue `%s` command above this message to receive a copy of the used command for your poll*"
         }
       }
     },

--- a/src/main/resources/translations/en.json
+++ b/src/main/resources/translations/en.json
@@ -1,0 +1,138 @@
+{
+  "translation": {
+    "name": "English",
+    "name_local": "English",
+    "code": "en",
+    "flag_unicode": "\uD83C\uDDFA\uD83C\uDDF8"
+  },
+  "polls": {
+    "question": "Question",
+    "choices": "Choices",
+    "yes": "Yes",
+    "no": "No",
+    "finalresult": "Final Result",
+    "alreadyended": "Poll already ended",
+    "ends": "Ends",
+    "multiplechoice": {
+      "allowed": "Multiple choices allowed",
+      "disallowed": "Multiple choices not allowed"
+    },
+    "noothervotes": "No other votes allowed",
+    "pollid": "Poll ID: %s"
+  },
+  "commands": {
+    "closepoll": {
+      "success": {
+        "title": "Poll closed",
+        "description": "The poll with ID **%s** was closed!\nNo more votes are allowed and the result is now displayed in the poll."
+      },
+      "failed": {
+        "title": "Poll can not be closed",
+        "description": "The poll with ID **%s** is already closed or does not exist!"
+      }
+    },
+    "help": {
+      "title": "EasyPoll Help",
+      "fields": {
+        "poll_commands": {
+          "title": ":bar_chart: Poll Commands",
+          "commands": {
+            "poll": "Create a normal poll without time limit",
+            "timepoll": "Create a timed poll, set an end date until when the poll will run",
+            "closepoll": "Close a poll so that no more votes are counted"
+          }
+        },
+        "public_commands": {
+          "title": ":mag_right: Public Commands",
+          "commands": {
+            "help": "Show this Bot Help",
+            "vote": "Vote for the EasyPoll Bot",
+            "invite": "Invite EasyPoll to your own Discord Server",
+            "info": "Show some information about EasyPoll",
+            "ping": "See the Ping of the Bot to the Discord Gateway"
+          }
+        }
+      }
+    },
+    "info": {
+      "title": "EasyPoll Information",
+      "fields": {
+        "creator": "Creator",
+        "repository": "Repository",
+        "version": "Version",
+        "library": "Library",
+        "servers": "Servers",
+        "users": "Users",
+        "shard": "Shard",
+        "uptime": "Uptime"
+      }
+    },
+    "invite": {
+      "title": "Invite EasyPoll",
+      "description": "You can invite %s here: [www.easypoll.me/invite](%s)"
+    },
+    "ping": {
+      "title": "Pong! :ping_pong:",
+      "description": "`Ping to Gateway %s ms`"
+    },
+    "poll": {
+      "invalid_time": {
+        "title": "Invalid time specification!",
+        "field": {
+          "title": "You have entered an invalid time!",
+          "description": "Use at the end of a number s (second), m (minute), h (hour), d (day) or w (week) for time specifications.\nExamples: 15m for 15 minutes, 1h for 1 hour, 3d for 3 days\n\n*PS: You will find your sent command of this poll to copy as a message to which I replied (click on the blue `/timepoll` command above this message)*"
+        }
+      },
+      "unknown_emoji": {
+        "title": "Unknown Emoji",
+        "field": {
+          "title": "You have specified an unknown emoji!",
+          "description": "Please make sure it is an **official Discord** emoji or an emoji **from this server**. EasyPoll can only use emojis from servers where EasyPoll is too.\n\n*PS: You will find your sent command of this poll to copy as a message to which I replied (click on the blue `%s` command above this message)*"
+        }
+      }
+    },
+    "setup": {
+      "language": {
+        "title": "Change Bot Language",
+        "description": "Here you can change the language of the Bot on this server.\nPlease select a new language:",
+        "selectionmenu": {
+          "placeholder": "Select a language.."
+        }
+      },
+      "permissions": {
+        "title": "Required Bot Permission Check",
+        "server_permissions": "Server Permissions",
+        "channel_permissions": "Channel Permissions",
+        "permissions": {
+          "message_read": "Read Messages",
+          "message_write": "Send Messages",
+          "message_manage": "Manage Messages",
+          "message_embed_links": "Embed Links",
+          "message_history": "Read message History",
+          "message_add_reaction": "Add Reactions",
+          "message_ext_emoji": "Use External Emojis"
+        }
+      }
+    },
+    "vote": {
+      "title": "Vote for EasyPoll",
+      "description": "We are happy that you want to vote for our bot. You show us that you like the bot and help us to grow further.\n\nYou can vote for us on the following pages:"
+    }
+  },
+  "errors": {
+    "no_permissions": {
+      "member": {
+        "title": "You do not have premissions to use this command!",
+        "field": {
+          "title": "To use this command you need at least one of them:"
+        }
+      },
+      "bot": {
+        "title": "I do not have the required permissions to perform all actions!",
+        "field": {
+          "title": "Please make sure that I have the following permissions:"
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/translations/en.json
+++ b/src/main/resources/translations/en.json
@@ -93,10 +93,17 @@
     },
     "setup": {
       "language": {
-        "title": "Change Bot Language",
-        "description": "Here you can change the language of the Bot on this server.\nPlease select a new language:",
-        "selectionmenu": {
-          "placeholder": "Select a language.."
+        "change": {
+          "title": "Change Bot Language",
+          "description": "Here you can change the language of the Bot on this server.\nPlease select a new language:",
+          "selectionmenu": {
+            "placeholder": "Select a language.."
+          }
+        },
+        "success": {
+          "title": "Bot language has been changed",
+          "description": "The Bot language on this server was successfully changed to **%s**.",
+          "footer": "Changed by %s"
         }
       },
       "permissions": {

--- a/src/main/resources/translations/fr-fr.json
+++ b/src/main/resources/translations/fr-fr.json
@@ -10,10 +10,10 @@
     "question": "Question",
     "choices": "Coix",
     "yes": "Oui",
-    "no": "non",
+    "no": "Non",
     "finalresult": "Résultat final",
     "alreadyended": "Sondage déja términé",
-    "ends": " se termine",
+    "ends": "Se termine",
     "multiplechoice": {
       "allowed": "Choix multiple autorisé",
       "disallowed": "Choix multiple non autorisé"
@@ -124,7 +124,7 @@
     },
     "vote": {
       "title": "Voter pour EasyPoll",
-      "description": "Nous sommes heureux, quand tu veux voter pour EasyPoll. Vous nous montrez que vous aimez le bot et aidez nous à grandir.\n\nAuf den folgenden Seiten kannst du für uns abstimmen:"
+      "description": "Nous sommes heureux, quand tu veux voter pour EasyPoll. Vous nous montrez que vous aimez le bot et aidez nous à grandir.\n\nVous pouvez votez pour nous sur les pages suivantes:"
     }
   },
   "errors": {

--- a/src/main/resources/translations/fr-fr.json
+++ b/src/main/resources/translations/fr-fr.json
@@ -1,0 +1,146 @@
+{
+  "translation": {
+    "name": "French",
+    "name_local": "Français",
+    "code": "fr-fr",
+    "flag_unicode": "\uD83C\uDDEB\uD83C\uDDF7",
+    "translators": "B_A_Baracus#0738 (353598885538693130)"
+  },
+  "polls": {
+    "question": "Question",
+    "choices": "Coix",
+    "yes": "Oui",
+    "no": "non",
+    "finalresult": "Résultat final",
+    "alreadyended": "Sondage déja términé",
+    "ends": " se termine",
+    "multiplechoice": {
+      "allowed": "Choix multiple autorisé",
+      "disallowed": "Choix multiple non autorisé"
+    },
+    "noothervotes": "Aucun autre vote autorisé",
+    "pollid": "ID du sondage: %s"
+  },
+  "commands": {
+    "closepoll": {
+      "success": {
+        "title": "Vous avez terminé le sondage",
+        "description": "Le sondage avec l'ID **%s** a été terminé!\nAucun autre vote autorisé et le résultat final est visible dans le sondage."
+      },
+      "failed": {
+        "title": "Le sondage n'a pas pu être terminé",
+        "description": "Le sondage avec l'ID **%s** a déjà été terminé ou n'existe pas!"
+      }
+    },
+    "help": {
+      "title": "Aide EasyPoll",
+      "fields": {
+        "poll_commands": {
+          "title": ":bar_chart: Commandes pour les sondages",
+          "commands": {
+            "poll": "Créer un sondage sans limite de temps",
+            "timepoll": "Créer un sondage avec limite de temps, ajouter une date de fin pour terminer le sondage automatiquement",
+            "closepoll": "Terminer un sondage pour ne plus compter de nouveaux votes"
+          }
+        },
+        "public_commands": {
+          "title": ":mag_right: Commandes publiquement",
+          "commands": {
+            "help": "Afficher cette Aide",
+            "vote": "Vote pour EasyPoll",
+            "invite": "Inviter EasyPoll sur votre Discord",
+            "info": "Afficher certains informations EasyPoll",
+            "ping": "Voir le latence de EasyPoll au Gateway"
+          }
+        }
+      }
+    },
+    "info": {
+      "title": "Informations d'EasyPoll",
+      "fields": {
+        "creator": "Développeur",
+        "repository": "Dépôt",
+        "version": "Version",
+        "library": "Library",
+        "servers": "Serveur",
+        "users": "Utilisator",
+        "shard": "Shard",
+        "uptime": "Disponiblité"
+      }
+    },
+    "invite": {
+      "title": "Inviter EasyPoll",
+      "description": "Inviter %s ici: [www.easypoll.me/invite](%s)"
+    },
+    "ping": {
+      "title": "Pong! :ping_pong:",
+      "description": "`Latence au Gateway %s ms`"
+    },
+    "poll": {
+      "invalid_time": {
+        "title": "Temps invalide!",
+        "field": {
+          "title": "Vous avez utilisé un temps invalide!",
+          "description": "Utlise s (seconde), m (minute), h (heure), d (jour) ou w (semaine) derrière un tems.\nExemples: 15m pour 15 minutes, 1h pour 1 heure, 3d pour 3 jours\n\n*PS: Cliquer sur le commande `/timepoll` dessous cette message pour reçevoir une copie de votre commande de votre sondage*"
+        }
+      },
+      "unknown_emoji": {
+        "title": "Emoji invalide!",
+        "field": {
+          "title": "Vous avez utilisé un emoji invalide!",
+          "description": "Utlisisez un emoji **Discord officiel** s.v.p. ou un emoji **de cet serveur** ou autres serveurs EasyPoll.\n\n*PS: Cliquer sur le commande `%s` dessous cette message pour reçevoir une copie de votre commande de votre sondage*"
+        }
+      }
+    },
+    "setup": {
+      "language": {
+        "change": {
+          "title": "Changer langue EasyPoll",
+          "description": "Ici vous pouvez changer la langue.\nChoisir la nouvelle language:",
+          "selectionmenu": {
+            "placeholder": "Choisir une langue"
+          }
+        },
+        "success": {
+          "title": "Vous avez changé langue EasyPoll",
+          "description": "La langue à changé en **%s** avec succès.",
+          "footer": "Changé par %s"
+        }
+      },
+      "permissions": {
+        "title": "Verfier l'autorisations",
+        "server_permissions": "L'autorisations serveur",
+        "channel_permissions": "L'autorisations channel",
+        "permissions": {
+          "message_read": "Lire des messages",
+          "message_write": "Envoyer des messages",
+          "message_manage": "Adminstrer des messages",
+          "message_embed_links": "Incorper des liens",
+          "message_history": "Voir histoire des messages",
+          "message_add_reaction": "Ajouter des reactions",
+          "message_ext_emoji": "Utiliser des emjois externes"
+        }
+      }
+    },
+    "vote": {
+      "title": "Voter pour EasyPoll",
+      "description": "Nous sommes heureux, quand tu veux voter pour EasyPoll. Vous nous montrez que vous aimez le bot et aidez nous à grandir.\n\nAuf den folgenden Seiten kannst du für uns abstimmen:"
+    }
+  },
+  "errors": {
+    "no_permissions": {
+      "member": {
+        "title": "Vous n'avez pas l'utorisation pur utiliser cette commande!",
+        "field": {
+          "title": "Pour utlisier cette commande, vous avez besoin d'au moins un de ces autorisations:"
+        }
+      },
+      "bot": {
+        "title": "Je n'ai pas les autisations nécessaires pour effectier cette action!",
+        "field": {
+          "title": "Verifier que j'ai les autorisations suivantes:"
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/translations/nl-nl.json
+++ b/src/main/resources/translations/nl-nl.json
@@ -1,0 +1,146 @@
+{
+    "translation": {
+        "name": "Dutch",
+        "name_local": "Nederlands",
+        "code": "nl-nl",
+        "flag_unicode": "\uD83C\uDDF3\uD83C\uDDF1",
+        "translators": "thefonz#2743 (423924063270993920)"
+    },
+    "polls": {
+        "question": "Vraag",
+        "choices": "Keuzes",
+        "yes": "Ja",
+        "no": "Nee",
+        "finalresult": "Eind resultaat",
+        "alreadyended": "Poll is al afgelopen",
+        "ends": "Eindigt",
+        "multiplechoice": {
+            "allowed": "Meerdere keuzes toegestaan",
+            "disallowed": "Meerdere keuzes niet toegestaan"
+        },
+        "noothervotes": "Geen andere stemmen toegestaan",
+        "pollid": "Poll ID: %s"
+    },
+    "commands": {
+        "closepoll": {
+            "success": {
+                "title": "Poll is gesloten",
+                "description": "Poll met id **%s** is gesloten!"
+            },
+            "failed": {
+                "title": "Poll kan niet gesloten worden",
+                "description": "De poll met ID **%s** is al gesloten en bestaat niet meer!"
+            }
+        },
+        "help": {
+            "title": "EasyPoll Hulp",
+            "fields": {
+                "poll_commands": {
+                    "title": "Overzicht van Poll opdrachten",
+                    "commands": {
+                        "poll": "Maak een normale poll zonder tijds limit",
+                        "timepoll": "Creëer een poll met tijds limit, en stel de datum tot wanneer de poll geldig is",
+                        "closepoll": "Sluit een poll zodat er geen stemming meegeteld worden"
+                    }
+                },
+                "public_commands": {
+                    "title": "Public opdrachten",
+                    "commands": {
+                        "help": "Laat de help van deze bot zien",
+                        "vote": "Stem voor de EasyPoll Bot",
+                        "invite": "Uitnodigen EasyPoll naar jouw eigen Discord Server",
+                        "info": "Laat wat informatie zien over EasyPoll",
+                        "ping": "Zie de ping van de Bot in de Discord Gateway"
+                    }
+                }
+            }
+        },
+        "info": {
+            "title": "EasyPoll informatie",
+            "fields": {
+                "creator": "Maker",
+                "repository": "Opslag",
+                "version": "Versie",
+                "library": "Bibliotheek",
+                "servers": "Server",
+                "users": "Gebruikers",
+                "shard": "Shard",
+                "uptime": "Uptime"
+            }
+        },
+        "invite": {
+            "title": "EasyPoll uitnodigen",
+            "description": "Jij kan uitnodigen %s here: [www.easypoll.me/invite](%s)"
+        },
+        "ping": {
+            "title": "Pong! :ping_pong:",
+            "description": "`Ping naar poort %s ms`"
+        },
+        "poll": {
+            "invalid_time": {
+                "title": "Tijd specificatie incorrect!",
+                "field": {
+                    "title": "Ingevoerde tijd is ongeldig",
+                    "description": "Gebruiker aan het eind nummers s (seconden), u (uren), d (dagen) of w (weken) voor tijd specifacties.\nBijvoorbeeld: 15m voor 15 minuten, 1h voor 1 uur, 3d voor 3 dagen.\n\n*PS: Je kan klikken op de blauw `/timepoll` opdracht hierboven dit bericht*"
+                }
+            },
+            "unknown_emoji": {
+                "title": "Onbekende Emoji",
+                "field": {
+                    "title": "Je hebt een onbekende emoji opgegeven!",
+                    "description": "Zorg ervoor dat het een **officiële Discord** emoji of een emoji **van deze server** is. EasyPoll kan alleen emoji's gebruiken van servers waar EasyPoll ook is.\n\n*PS: U kunt op het blauwe `%s`-commando boven dit bericht klikken om een kopie van het gebruikte commando voor uw poll te ontvangen*"
+                }
+            }
+        },
+        "setup": {
+            "language": {
+                "change": {
+                    "title": "Bottaal wijzigen",
+                    "description": "Hier kunt u de taal van de Bot op deze server wijzigen.\nSelecteer een nieuwe taal:",
+                    "selectionmenu": {
+                        "placeholder": "Selecteer een taal"
+                    }
+                },
+                "success": {
+                    "title": "Bot taal is veranderd",
+                    "description": "De bot taal op deze server is met success veranderd naar **%s**.",
+                    "footer": "Veranderd by %s"
+                }
+            },
+            "permissions": {
+                "title": "Toestemming Bot controle",
+                "server_permissions": "Server toegangen",
+                "channel_permissions": "Kanalen toegangen",
+                "permissions": {
+                    "message_read": "Lees berichten",
+                    "message_write": "Stuur berichten",
+                    "message_manage": "Beheer berichten",
+                    "message_embed_links": "Koppelingen insluiten",
+                    "message_history": "Berichtgeschiedenis lezen",
+                    "message_add_reaction": "Reactie toevoegen",
+                    "message_ext_emoji": "Gebruik externe Emojis"
+                }
+            }
+        },
+        "vote": {
+            "title": "Stem voor EasyPoll",
+            "description": "We zijn gelukkig dat je wilt stemmen op onze Bot. Jij laat ons zien dat jij onze bot leuk vind en dit helpt ons verder groeien.\n\nJij kan voor ons stemmen op de volgende paginas:"
+        }
+    },
+    "errors": {
+        "no_permissions": {
+            "member": {
+                "title": "Jij hebt geen toestemming om deze commando te gebruiken!",
+                "field": {
+                    "title": "Om dit commando te gebruiken heb je er minstens één nodig:"
+                }
+            },
+            "bot": {
+                "title": "Jij heb niet de bedonigde rechten om alle uit acties uit te voeren!",
+                "field": {
+                    "title": "Zorg ervoor dat ik de volgende toegang heb:"
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/translations/pt-br.json
+++ b/src/main/resources/translations/pt-br.json
@@ -81,14 +81,14 @@
                 "title": "Tempo especificado inválido!",
                 "field": {
                     "title": "Você colocou um tempo inválido!",
-                    "description": "Use no fim do número um s (segundo), m (minuto), h (hora), d (dia) ou w (semana) para especificações de tempo.\nExemplos: 15m para 15 minutos, 1h para 1 hora, 3d para 3 dias\n\n*Obs.: Você pode clicar no comando azul '/timepoll' abaixo dessa mensagem para receber uma cópia dos comandos usados para sua enquete.*"
+                    "description": "Use no fim do número um s (segundo), m (minuto), h (hora), d (dia) ou w (semana) para especificações de tempo.\nExemplos: 15m para 15 minutos, 1h para 1 hora, 3d para 3 dias\n\n*Obs.: Você pode clicar no comando azul `/timepoll` acima desta mensagem para receber uma cópia dos comandos usados para sua enquete.*"
                 }
             },
             "unknown_emoji": {
                 "title": "Emoji desconhecido",
                 "field": {
                     "title": "Você especificou um emoji desconhecido!",
-                    "description": "Por favor confira se esse é um emoji **oficial do Discord** ou um emoji **desse servidor**. EasyPoll pode usar apenas emojis de servidores onde o EasyPoll também está.\n\n*Obs.: Você pode clicar no comando azul '%s' abaixo dessa mensagem para receber uma cópia dos comandos usados para sua enquete.*"
+                    "description": "Por favor confira se esse é um emoji **oficial do Discord** ou um emoji **desse servidor**. EasyPoll pode usar apenas emojis de servidores onde o EasyPoll também está.\n\n*Obs.: Você pode clicar no comando azul `%s` acima dessa mensagem para receber uma cópia dos comandos usados para sua enquete*"
                 }
             }
         },
@@ -124,7 +124,7 @@
         },
         "vote": {
             "title": "Votar no EasyPoll",
-            "description": "Estamos felizes que você queira votar em nosso bot. Você nos mostra que gosta do bot e nos ajuda a crescer ainda mais.\n\nVocê pode votar em nós nas seguintes páginas:"
+            "description": "Estamos felizes que você queira votar em nosso bot. Nos mostra que gosta do bot e nos ajuda a crescer ainda mais.\n\nVocê pode votar em nós nas seguintes páginas:"
         }
     },
     "errors": {

--- a/src/main/resources/translations/pt-br.json
+++ b/src/main/resources/translations/pt-br.json
@@ -1,0 +1,146 @@
+{
+    "translation": {
+        "name": "Portuguese (Brazilian)",
+        "name_local": "Português do Brasil",
+        "code": "pt-br",
+        "flag_unicode": "\uD83C\uDDE7\uD83C\uDDF7",
+        "translators": "eumakoto#4496 (697609857175650405), Marcos Rosa#7350 (690189535879233572)"
+    },
+    "polls": {
+        "question": "Questão",
+        "choices": "Alternativas",
+        "yes": "Sim",
+        "no": "Não",
+        "finalresult": "Resultado Final",
+        "alreadyended": "A enquete já terminou",
+        "ends": "Termina",
+        "multiplechoice": {
+            "allowed": "Múltipla escolha permitida",
+            "disallowed": "Múltipla escolha não permitida"
+        },
+        "noothervotes": "Votos não são mais permitidos",
+        "pollid": "ID da enquete: %s"
+    },
+    "commands": {
+        "closepoll": {
+            "success": {
+                "title": "Enquete fechada",
+                "description": "A enquete de ID **%s** estava fechada!\nVotos não são mais permitidos e o resultado está exibido na enquete."
+            },
+            "failed": {
+                "title": "Esta enquete não pode ser fechada",
+                "description": "A enquete de ID **%s** já está fechada ou não existe mais!"
+            }
+        },
+        "help": {
+            "title": "EasyPoll Ajuda",
+            "fields": {
+                "poll_commands": {
+                    "title": ":bar_chart: Comandos de Enquete",
+                    "commands": {
+                        "poll": "Criar uma enquete normal sem tempo limite",
+                        "timepoll": "Criar uma enquete temporária, com data limite para votações",
+                        "closepoll": "Fechar uma enquete para parar a contagem de votos"
+                    }
+                },
+                "public_commands": {
+                    "title": ":mag_right: Comandos Públicos",
+                    "commands": {
+                        "help": "Mostrar a Ajuda deste Bot",
+                        "vote": "Vote no EasyPoll Bot",
+                        "invite": "Convidar o EasyPoll para seu servidor no Discord",
+                        "info": "Mostrar informações sobre o EasyPoll",
+                        "ping": "Ver o Ping do bot para o Gateway do Discord"
+                    }
+                }
+            }
+        },
+        "info": {
+            "title": "Informações sobre o EasyPoll",
+            "fields": {
+                "creator": "Criador",
+                "repository": "Repositório",
+                "version": "Versão",
+                "library": "Biblioteca",
+                "servers": "Servidores",
+                "users": "Usuários",
+                "shard": "Fragmento",
+                "uptime": "Tempo de atividade"
+            }
+        },
+        "invite": {
+            "title": "Convidar EasyPoll",
+            "description": "Você pode convidar %s aqui: [www.easypoll.me/invite](%s)"
+        },
+        "ping": {
+            "title": "Pong! :ping_pong:",
+            "description": "Ping para o Gateway %s ms"
+        },
+        "poll": {
+            "invalid_time": {
+                "title": "Tempo especificado inválido!",
+                "field": {
+                    "title": "Você colocou um tempo inválido!",
+                    "description": "Use no fim do número um s (segundo), m (minuto), h (hora), d (dia) ou w (semana) para especificações de tempo.\nExemplos: 15m para 15 minutos, 1h para 1 hora, 3d para 3 dias\n\n*Obs.: Você pode clicar no comando azul '/timepoll' abaixo dessa mensagem para receber uma cópia dos comandos usados para sua enquete.*"
+                }
+            },
+            "unknown_emoji": {
+                "title": "Emoji desconhecido",
+                "field": {
+                    "title": "Você especificou um emoji desconhecido!",
+                    "description": "Por favor confira se esse é um emoji **oficial do Discord** ou um emoji **desse servidor**. EasyPoll pode usar apenas emojis de servidores onde o EasyPoll também está.\n\n*Obs.: Você pode clicar no comando azul '%s' abaixo dessa mensagem para receber uma cópia dos comandos usados para sua enquete.*"
+                }
+            }
+        },
+        "setup": {
+            "language": {
+                "change": {
+                    "title": "Alterar idioma do Bot",
+                    "description": "Aqui você pode alterar o idioma do Bot nesse servidor.\nPor favor selecione um novo idioma:",
+                    "selectionmenu": {
+                        "placeholder": "Selecione um idioma.."
+                    }
+                },
+                "success": {
+                    "title": "Idioma do Bot alterado",
+                    "description": "O idioma do Bot nesse servidor foi alterado com sucesso para **%s**.",
+                    "footer": "Alterado por %s"
+                }
+            },
+            "permissions": {
+                "title": "Verificação de permissão do Bot necessária",
+                "server_permissions": "Permissões do Servidor",
+                "channel_permissions": "Permissões de Canal",
+                "permissions": {
+                    "message_read": "Ler Mensagens",
+                    "message_write": "Enviar Mensagens",
+                    "message_manage": "Gerenciar Mensagens",
+                    "message_embed_links": "Links Incorporados",
+                    "message_history": "Ler Histórico de mensagens",
+                    "message_add_reaction": "Adicionar Reações",
+                    "message_ext_emoji": "Usar Emojis Externos"
+                }
+            }
+        },
+        "vote": {
+            "title": "Votar no EasyPoll",
+            "description": "Estamos felizes que você queira votar em nosso bot. Você nos mostra que gosta do bot e nos ajuda a crescer ainda mais.\n\nVocê pode votar em nós nas seguintes páginas:"
+        }
+    },
+    "errors": {
+        "no_permissions": {
+            "member": {
+                "title": "Você não tem permissão para usar esse comando!",
+                "field": {
+                    "title": "Para usar este comando, você precisa de pelo menos um deles:"
+                }
+            },
+            "bot": {
+                "title": "Não tenho as permissões necessárias para realizar todas as ações!",
+                "field": {
+                    "title": "Certifique-se de que tenho as seguintes permissões:"
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/translations/zh-tw.json
+++ b/src/main/resources/translations/zh-tw.json
@@ -1,0 +1,146 @@
+{
+    "translation": {
+        "name": "Chinese (traditional)",
+        "name_local": "中文 (繁体)",
+        "code": "zh-tw",
+        "flag_unicode": "\uD83C\uDDE8\uD83C\uDDF3",
+        "translators": "nado#2213 (678148708373626881)"
+    },
+    "polls": {
+        "question": "問題",
+        "choices": "選擇",
+        "yes": "是",
+        "no": "不是",
+        "finalresult": "最終結果",
+        "alreadyended": "投票已經結束",
+        "ends": "結束",
+        "multiplechoice": {
+            "allowed": "允許多重選擇",
+            "disallowed": "不允許多重選擇"
+        },
+        "noothervotes": "停止接受其他投票",
+        "pollid": "投票ID: %s"
+    },
+    "commands": {
+        "closepoll": {
+            "success": {
+                "title": "投票結束",
+                "description": "投票 (ID: **%s**) 已經結束!\n已停止接受其他投票，投票結果會顯示在投票裡。"
+            },
+            "failed": {
+                "title": "投票不能結束",
+                "description": "投票 (ID: **%s**) 已經結束或不存在!"
+            }
+        },
+        "help": {
+            "title": "EasyPoll 幫助",
+            "fields": {
+                "poll_commands": {
+                    "title": ":bar_chart: 投票指令",
+                    "commands": {
+                        "poll": "創建一個沒有時間限制的普通投票",
+                        "timepoll": "創建定時投票，並設置結束日期直到投票運行",
+                        "closepoll": "結束投票以不再計算新選票"
+                    }
+                },
+                "public_commands": {
+                    "title": ":mag_right: 公共指令",
+                    "commands": {
+                        "help": "顯示此機器人幫助",
+                        "vote": "為Easypoll機器人投票",
+                        "invite": "邀請Easypoll進入你的Discord伺服器",
+                        "info": "顯示關於Easypoll的一些資訊",
+                        "ping": "查看機器人對Discord網關的呯(Ping)"
+                    }
+                }
+            }
+        },
+        "info": {
+            "title": "EasyPoll資訊",
+            "fields": {
+                "creator": "創作者",
+                "repository": "存儲庫",
+                "version": "版本",
+                "library": "資料庫",
+                "servers": "伺服器",
+                "users": "用戶",
+                "shard": "碎片",
+                "uptime": "運行時間"
+            }
+        },
+        "invite": {
+            "title": "邀請EasyPoll",
+            "description": "你可以邀請 %s 在這裡: [www.easypoll.me/invite](%s)"
+        },
+        "ping": {
+            "title": "乓! :ping_pong:",
+            "description": "`呯(Ping) 到網關 %s ms`"
+        },
+        "poll": {
+            "invalid_time": {
+                "title": "無效的時間範圍說明!",
+                "field": {
+                    "title": "您輸入了一個無效的時間!",
+                    "description": "將 s (秒), m (分鐘), h (小時), d (天), w (週) 用在一個數字的後面以說明時間範圍。\n例子: 15m (即15分鐘), 1h (即1小時), 3d (即3天)\n\n*提示: 你可以點擊在這條信息上面的藍色 `/timepoll` 指令來獲取一份用於投票的指令的拷貝文件*"
+                }
+            },
+            "unknown_emoji": {
+                "title": "未知的表情符號 (Emoji)",
+                "field": {
+                    "title": "你列舉了一個未知的表情符號 (Emoji)!",
+                    "description": "請確保這是一個 **Discord官方** 的表情符號 (Emoji) 或是 **來自這個伺服器** 的表情符號 (Emoji)。EasyPoll只能夠在其加入的伺服器內使用該伺服器的表情符號 (Emoji)。\n\n*提示: 你可以點擊在這條信息上面的藍色 `%s` 指令來獲取一份用於投票的指令的拷貝文件*"
+                }
+            }
+        },
+        "setup": {
+            "language": {
+                "change": {
+                    "title": "更換Easypoll的語言",
+                    "description": "你可以在這裡更換機器人的語言。\n請選擇一個新的語言:",
+                    "selectionmenu": {
+                        "placeholder": "選擇一個語言.."
+                    }
+                },
+                "success": {
+                    "title": "機器人的語言已經被變更",
+                    "description": "這個伺服器上的機器人的語言己經成功地被變更為 **%s** 。",
+                    "footer": "被 %s 變更"
+                }
+            },
+            "permissions": {
+                "title": "請求機器人權限檢查",
+                "server_permissions": "伺服器權限",
+                "channel_permissions": "頻道權限",
+                "permissions": {
+                    "message_read": "閱讀信息",
+                    "message_write": "發送信息",
+                    "message_manage": "管理訊息",
+                    "message_embed_links": "嵌入連接",
+                    "message_history": "閱讀歷史訊息",
+                    "message_add_reaction": "添加反應",
+                    "message_ext_emoji": "使用外部表情符號 (Emoji)"
+                }
+            }
+        },
+        "vote": {
+            "title": "為EasyPoll投票",
+            "description": "我們為你們想為我們投票而感到開心。你向我們表明您你喜歡使用這個機器人並幫助我們進一步發展。\n\n你可以在以下頁面為我們投票:"
+        }
+    },
+    "errors": {
+        "no_permissions": {
+            "member": {
+                "title": "你沒有權限來使用此指令!",
+                "field": {
+                    "title": "你至少需要其中一個來使用此指令:"
+                }
+            },
+            "bot": {
+                "title": "我沒有必要的權限來執行所有操作!",
+                "field": {
+                    "title": "請確保我有以下的權限:"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Please read the contributing guidelines to contribute properly!
Contributing Guidelines: https://github.com/fbrettnich/easypoll-bot/blob/main/.github/CONTRIBUTING.md
-->

### Changes

- [x] New feature
- [ ] Bug fixes
- [ ] Documentation
- [ ] Other: \___ <!-- Insert another type -->

Closes #11 <!-- Replace 'NaN' with a issue number that belongs to this pull request. -->

### Description
This pull request introduces a system, which makes it possible to change the language of the bot on the own server.
Server owners have the possibility to select their preferred language from a list. The bot is then completely available in this language.
Translations are stored in Json files and can be extended by any number of languages at any time.
